### PR TITLE
The number of iterator records are now customizable.

### DIFF
--- a/src/WebConnector/Messages/StepQueryWithIterator.cs
+++ b/src/WebConnector/Messages/StepQueryWithIterator.cs
@@ -8,6 +8,7 @@ namespace QbSync.WebConnector.Messages
         where Y : class, QbIteratorResponse, QbResponse, new()
     {
         internal const string IteratorKey = "Iterator";
+        private const string MaxReturnedDefault = "100";
         private bool gotoNextStep = true;
 
         public StepQueryWithIterator()
@@ -26,7 +27,14 @@ namespace QbSync.WebConnector.Messages
                 request.iteratorID = savedMessage;
             }
 
-            request.MaxReturned = "100";
+            int maxVal;
+            bool isValid = int.TryParse(request.MaxReturned, out maxVal);
+
+            if (!isValid || (isValid && (maxVal < 1)))
+            {
+                // Not a valid max returned value. Set to 100 by default.
+                request.MaxReturned = MaxReturnedDefault;
+            }
 
             return base.ExecuteRequest(authenticatedTicket, request);
         }

--- a/test/WebConnector.Tests/Helpers/StepQueryWithIteratorMaxReturnedHarness.cs
+++ b/test/WebConnector.Tests/Helpers/StepQueryWithIteratorMaxReturnedHarness.cs
@@ -1,0 +1,22 @@
+﻿using QbSync.QbXml.Objects;
+using QbSync.WebConnector.Messages;
+
+namespace QbSync.WebConnector.Tests.Helpers
+{
+    public abstract class StepQueryWithIteratorMaxReturnedHarness : StepQueryWithIterator<CustomerQueryRqType, CustomerQueryRsType>
+    {
+        public StepQueryWithIteratorMaxReturnedHarness(string defaultMaxReturned)
+        {
+            this.DefaultMaxReturned = defaultMaxReturned;
+        }
+
+        protected override CustomerQueryRqType CreateRequest(AuthenticatedTicket authenticatedTicket)
+        {
+            CustomerQueryRqType req = base.CreateRequest(authenticatedTicket);
+            req.MaxReturned = this.DefaultMaxReturned;
+            return req;
+        }
+
+        public string DefaultMaxReturned { get; private set; }
+    }
+}

--- a/test/WebConnector.Tests/StepQueryWithIteratorTests.cs
+++ b/test/WebConnector.Tests/StepQueryWithIteratorTests.cs
@@ -6,6 +6,7 @@ using QbSync.QbXml.Objects;
 using QbSync.WebConnector.Messages;
 using QbSync.WebConnector.Tests.Helpers;
 using System;
+using System.Reflection;
 using System.Xml;
 
 namespace QbSync.WebConnector.Tests
@@ -236,6 +237,116 @@ namespace QbSync.WebConnector.Tests
             stepQueryWithIteratorMock
                 .Protected()
                 .Verify("ExecuteResponse", Times.Once(), ItExpr.IsAny<AuthenticatedTicket>(), ItExpr.Is<CustomerQueryRsType>(m => m.CustomerRet[0].TimeModified.ToDateTime().ToUniversalTime().Hour == expectedHour));
+        }
+
+        [Test]
+        public void CustomerQueryWithIteratorInvalidMaxReturned()
+        {
+            const int expectedMaxResult = 100;
+
+            var defaultMaxResult = "INVALID_MAX_RETURN_VALUE";
+            var authenticatedTicket = new AuthenticatedTicket
+            {
+                Ticket = Guid.NewGuid().ToString(),
+                CurrentStep = "step4"
+            };
+
+            var stepQueryWithIteratorMock = new Mock<StepQueryWithIteratorMaxReturnedHarness>(defaultMaxResult);
+            stepQueryWithIteratorMock.CallBase = true;
+
+            var xml = stepQueryWithIteratorMock.Object.SendXML(authenticatedTicket);
+
+            XmlDocument requestXmlDoc = new XmlDocument();
+            requestXmlDoc.LoadXml(xml);
+
+            var node = requestXmlDoc.SelectSingleNode("//CustomerQueryRq");
+
+            Assert.IsNotNull(node);
+            Assert.AreEqual("Start", node.Attributes.GetNamedItem("iterator").Value);
+            Assert.IsNotNull(node.SelectSingleNode("MaxReturned"));
+            Assert.AreEqual(expectedMaxResult.ToString(), node.SelectSingleNode("MaxReturned").InnerText);
+        }
+
+        [Test]
+        public void CustomerQueryWithIteratorZeroMaxReturned()
+        {
+            const int expectedMaxResult = 100;
+
+            var defaultMaxResult = "0";
+            var authenticatedTicket = new AuthenticatedTicket
+            {
+                Ticket = Guid.NewGuid().ToString(),
+                CurrentStep = "step4"
+            };
+
+            var stepQueryWithIteratorMock = new Mock<StepQueryWithIteratorMaxReturnedHarness>(defaultMaxResult);
+            stepQueryWithIteratorMock.CallBase = true;
+
+            var xml = stepQueryWithIteratorMock.Object.SendXML(authenticatedTicket);
+
+            XmlDocument requestXmlDoc = new XmlDocument();
+            requestXmlDoc.LoadXml(xml);
+
+            var node = requestXmlDoc.SelectSingleNode("//CustomerQueryRq");
+
+            Assert.IsNotNull(node);
+            Assert.AreEqual("Start", node.Attributes.GetNamedItem("iterator").Value);
+            Assert.IsNotNull(node.SelectSingleNode("MaxReturned"));
+            Assert.AreEqual(expectedMaxResult.ToString(), node.SelectSingleNode("MaxReturned").InnerText);
+        }
+
+        [Test]
+        public void CustomerQueryWithIteratorNegativeMaxReturned()
+        {
+            const int expectedMaxResult = 100;
+
+            var defaultMaxResult = "-1";
+            var authenticatedTicket = new AuthenticatedTicket
+            {
+                Ticket = Guid.NewGuid().ToString(),
+                CurrentStep = "step4"
+            };
+
+            var stepQueryWithIteratorMock = new Mock<StepQueryWithIteratorMaxReturnedHarness>(defaultMaxResult);
+            stepQueryWithIteratorMock.CallBase = true;
+
+            var xml = stepQueryWithIteratorMock.Object.SendXML(authenticatedTicket);
+
+            XmlDocument requestXmlDoc = new XmlDocument();
+            requestXmlDoc.LoadXml(xml);
+
+            var node = requestXmlDoc.SelectSingleNode("//CustomerQueryRq");
+
+            Assert.IsNotNull(node);
+            Assert.AreEqual("Start", node.Attributes.GetNamedItem("iterator").Value);
+            Assert.IsNotNull(node.SelectSingleNode("MaxReturned"));
+            Assert.AreEqual(expectedMaxResult.ToString(), node.SelectSingleNode("MaxReturned").InnerText);
+        }
+
+        [Test]
+        public void CustomerQueryWithIteratorValidMaxReturned()
+        {
+            string defaultMaxResult = "500";
+            var authenticatedTicket = new AuthenticatedTicket
+            {
+                Ticket = Guid.NewGuid().ToString(),
+                CurrentStep = "step4"
+            };
+
+            var stepQueryWithIteratorMock = new Mock<StepQueryWithIteratorMaxReturnedHarness>(defaultMaxResult);
+            stepQueryWithIteratorMock.CallBase = true;
+
+            var xml = stepQueryWithIteratorMock.Object.SendXML(authenticatedTicket);
+
+            XmlDocument requestXmlDoc = new XmlDocument();
+            requestXmlDoc.LoadXml(xml);
+
+            var node = requestXmlDoc.SelectSingleNode("//CustomerQueryRq");
+
+            Assert.IsNotNull(node);
+            Assert.AreEqual("Start", node.Attributes.GetNamedItem("iterator").Value);
+            Assert.IsNotNull(node.SelectSingleNode("MaxReturned"));
+            Assert.AreEqual(defaultMaxResult.ToString(), node.SelectSingleNode("MaxReturned").InnerText);
         }
     }
 }

--- a/test/WebConnector.Tests/WebConnector.Tests.csproj
+++ b/test/WebConnector.Tests/WebConnector.Tests.csproj
@@ -66,6 +66,7 @@
     <Compile Include="Helpers\QuickBooksTestHelper.cs" />
     <Compile Include="Helpers\SetupValidTicketAttribute.cs" />
     <Compile Include="Helpers\SetupInvalidTicketAttribute.cs" />
+    <Compile Include="Helpers\StepQueryWithIteratorMaxReturnedHarness.cs" />
     <Compile Include="StepQueryWithIteratorTests.cs" />
     <Compile Include="SyncManagerTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />


### PR DESCRIPTION
This is actually my first fork and pull request, as well as writing solid unit test code with Moq. Please let me know if anything needs to be changed or improved. I tried to follow the direction of @jsgoupil to write consistent unit tests.

Also, is there a better way to set that `MaxReturned` property without a harness class?
