### PR TITLE
SyncManager does not execute next step in ReceiveRequestXML

### DIFF
--- a/src/WebConnector/SyncManager.cs
+++ b/src/WebConnector/SyncManager.cs
@@ -230,8 +230,8 @@ namespace QbSync.WebConnector
 
                     if (authenticatedTicket != null)
                     {
-                        StepQueryResponse stepQueryResponse = FindStep(authenticatedTicket.CurrentStep);
-                        if (stepQueryResponse != null)
+                        StepQueryResponse stepQueryResponse = null;
+                        while ((stepQueryResponse = FindStep(authenticatedTicket.CurrentStep)) != null)
                         {
                             stepQueryResponse.SetOptions(GetOptions(authenticatedTicket));
                             result = stepQueryResponse.ReceiveXML(authenticatedTicket, response, hresult, message);
@@ -249,6 +249,14 @@ namespace QbSync.WebConnector
                                 {
                                     authenticatedTicket.CurrentStep = FindNextStepName(authenticatedTicket.CurrentStep);
                                 }
+                                else
+                                {
+                                    break;
+                                }
+                            }
+                            else
+                            {
+                                break;
                             }
                         }
                     }


### PR DESCRIPTION
I may have misunderstood something in the configuration, but it appears that if two or more steps are registered in the SyncManager then ReceiveXML will be called for the first, but even though authenticatedTicket.CurrentStep is set to the next step it is not executed. I based this pull request off of the way SyncManager.SendRequestXML falls through to the next step. I also added a unit test to demonstrate the issue. Please let me know if I misunderstood something in the configuration.
