### PR TITLE
Updated QB invalid datetime parsing

### DIFF
--- a/src/QbXml/Objects/Types/DATETIMETYPE.cs
+++ b/src/QbXml/Objects/Types/DATETIMETYPE.cs
@@ -167,7 +167,9 @@ namespace QbSync.QbXml.Objects
             reader.ReadStartElement();
             if (!isEmptyElement)
             {
-                value = DateTime.Parse(reader.ReadContentAsString());
+                DateTime dt;
+                DateTime.TryParse(reader.ReadContentAsString(), out dt);
+                value = dt;
                 reader.ReadEndElement();
             }
         }


### PR DESCRIPTION
A recent update in QuickBooks now apparently sends invalid datetimes (e.g. 0000-00-00). This change incorporates a DateTime.TryParse() instead of DateTime.Parse().
