### PR TITLE
Corrected use of IsSubclassOf() to IsAssignableFrom().

### DIFF
--- a/src/QbXml/QbXmlResponse.cs
+++ b/src/QbXml/QbXmlResponse.cs
@@ -64,7 +64,7 @@ namespace QbSync.QbXml
                 {
                     foreach (var innerItem in typedItem.Items)
                     {
-                        if (innerItem.GetType() == type || innerItem.GetType().IsSubclassOf(type))
+                        if (innerItem.GetType() == type || type.IsAssignableFrom(innerItem.GetType()))
                         {
                             yield return innerItem;
                         }


### PR DESCRIPTION
This is the correct usage. Not sure how the other usage slipped in.
