### PR TITLE
Update DATETIMETYPE for better QuickBooks UTC offset bug handling

### DIFF
--- a/src/QbXml/Objects/Types/DATETIMETYPE.cs
+++ b/src/QbXml/Objects/Types/DATETIMETYPE.cs
@@ -14,7 +14,7 @@ namespace QbSync.QbXml.Objects
         private bool _canReadXml;
         private readonly bool _isLocal;
 
-        //Private constructor as only xml deserialization should be using this
+        // Private constructor as only xml deserialization should be using this
         private DATETIMETYPE()
         {
             _canReadXml = true;
@@ -46,7 +46,7 @@ namespace QbSync.QbXml.Objects
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DATETIMETYPE"/> class using the specified <see cref="DateTime"/>.
-        /// IMPORTANT NOTE: The <see cref="DateTime.Kind"/> property of the <see cref="value"/> will be used to determine 
+        /// NOTE: The <see cref="DateTime.Kind"/> property of the <see cref="value"/> will be used to determine 
         /// if and what offset should be used when sending the value to QuickBooks. 
         /// <see cref="DateTimeKind"/>.<see cref="DateTimeKind.Utc"/> will use "+00:00".
         /// <see cref="DateTimeKind"/>.<see cref="DateTimeKind.Local"/> will use the offset as determined by the timezone of the machine this application is running on.

--- a/src/QbXml/Objects/Types/DATETIMETYPE.cs
+++ b/src/QbXml/Objects/Types/DATETIMETYPE.cs
@@ -1,106 +1,212 @@
 ﻿using System;
 using System.Globalization;
+using System.Linq;
+using System.Text.RegularExpressions;
 using System.Xml.Serialization;
 
 namespace QbSync.QbXml.Objects
 {
     public partial class DATETIMETYPE : ITypeWrapper, IComparable<DATETIMETYPE>, IXmlSerializable
     {
-        private DateTime _value;
-        protected TimeZoneInfo timeZoneInfo;
+        private DateTimeOffset _value;
 
-        public DATETIMETYPE()
-            : this((TimeZoneInfo)null)
+        private bool _ignoreOffset;
+        private bool _canReadXml;
+        private readonly bool _isLocal;
+
+        //Private constructor as only xml deserialization should be using this
+        private DATETIMETYPE()
         {
-            // Used for serialization
-            if (QbXmlResponse.qbXmlResponseOptionsStatic != null)
-            {
-                this.timeZoneInfo = QbXmlResponse.qbXmlResponseOptionsStatic.TimeZoneBugFix;
-            }
+            _canReadXml = true;
         }
 
-        public DATETIMETYPE(TimeZoneInfo timeZoneInfo)
-            : this(default(DateTime), timeZoneInfo)
-        {
-            this.timeZoneInfo = timeZoneInfo;
-        }
-
+        
+        [Obsolete("Use static DATETIMETYPE.Parse")]
         public DATETIMETYPE(string value)
-            : this(value, null)
+        {
+            _value = ParseValue(value, out _ignoreOffset);
+
+            if (this > MaxValue)
+            {
+                throw new ArgumentOutOfRangeException(nameof(value), value, "The supplied value is greater than the QuickBooks epoch of 2038-01-19T03:14:07+00:00");
+            }
+
+            if (this < MinValue)
+            {
+                throw new ArgumentOutOfRangeException(nameof(value), value, "The supplied value is less than the minimum allowed date of 1970-01-01");
+            }
+        }
+
+        [Obsolete("TimeZoneInfo is no longer used. Use static DATETIMETYPE.Parse")]
+        public DATETIMETYPE(string value, TimeZoneInfo timeZoneInfo) 
+            : this(value)
         {
         }
 
-        public DATETIMETYPE(string value, TimeZoneInfo timeZoneInfo)
-            : this(Parse(value), timeZoneInfo)
-        {
-        }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DATETIMETYPE"/> class using the specified <see cref="DateTime"/>.
+        /// IMPORTANT NOTE: The <see cref="DateTime.Kind"/> property of the <see cref="value"/> will be used to determine 
+        /// if and what offset should be used when sending the value to QuickBooks. 
+        /// <see cref="DateTimeKind"/>.<see cref="DateTimeKind.Utc"/> will use "+00:00".
+        /// <see cref="DateTimeKind"/>.<see cref="DateTimeKind.Local"/> will use the offset as determined by the timezone of the machine this application is running on.
+        /// <see cref="DateTimeKind"/>.<see cref="DateTimeKind.Unspecified"/> will use no offset, which QuickBooks will interpret to mean the local time of the QuickBooks host computer.
+        /// </summary>
+        /// <seealso cref="DateTimeKind"/>
         public DATETIMETYPE(DateTime value)
-            : this(value, null)
         {
+            if (value.Kind == DateTimeKind.Utc)
+            {
+                _value = new DateTimeOffset(value, TimeSpan.Zero);
+            }
+            else if (value.Kind == DateTimeKind.Local)
+            {
+                _value = new DateTimeOffset(value);
+                _isLocal = true;
+            }
+            else
+            {
+                _ignoreOffset = true;
+                _value = new DateTimeOffset(value, TimeSpan.Zero);
+            }
+
+            if (this > MaxValue)
+            {
+                throw new ArgumentOutOfRangeException(nameof(value), value, "The supplied value is greater than the QuickBooks epoch of 2038-01-19T03:14:07+00:00");
+            }
+
+            if (this < MinValue)
+            {
+                throw new ArgumentOutOfRangeException(nameof(value), value, "The supplied value is less than the minimum allowed date of 1970-01-01");
+            }
         }
 
+
+        [Obsolete("TimeZoneInfo is no longer used. Use overload without timeZoneInfo")]
         public DATETIMETYPE(DateTime value, TimeZoneInfo timeZoneInfo)
+            : this (value)
         {
-            Init(value, timeZoneInfo);
         }
 
-        private void Init(DateTime value, TimeZoneInfo timeZoneInfo)
-        {
-            this.timeZoneInfo = timeZoneInfo;
 
-            this.value = value;
-        }
-
-        protected DateTime value
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DATETIMETYPE"/> class using the specified <see cref="DateTimeOffset"/>.
+        /// <see cref="HasOffset"/> will always be true, and the supplied offset will be included with requests to QuickBooks.
+        /// </summary>
+        /// <param name="value">The <see cref="DateTimeOffset"/> value</param>
+        public DATETIMETYPE(DateTimeOffset value)
         {
-            get
+            _value = value;
+
+            if (this > MaxValue)
             {
-                return this._value;
+                throw new ArgumentOutOfRangeException(nameof(value), value, "The supplied value is greater than the QuickBooks epoch of 2038-01-19T03:14:07+00:00");
             }
 
-            set
+            if (this < MinValue)
             {
-                this._value = value;
-
-                // Mono Build does not like having IsDaylightSavingTime with an invalid date.
-                // Let's make a check here.
-                if (this.value != DateTime.MinValue)
-                {
-                    if (timeZoneInfo != null && timeZoneInfo.IsDaylightSavingTime(this.value))
-                    {
-                        // QuickBooks does not handle DST. They will send the date with no DST applied.
-                        // In order to get the correct date, we modify the date if a timezone was provided and
-                        // apply the daylight time saving manually if the date is currently in DST mode.
-                        foreach (var adjustmentRule in timeZoneInfo.GetAdjustmentRules())
-                        {
-                            if (this._value.CompareTo(adjustmentRule.DateStart) > 0 && this._value.CompareTo(adjustmentRule.DateEnd) < 0)
-                            {
-                                this._value = this.value.Add(-adjustmentRule.DaylightDelta);
-                                break;
-                            }
-                        }
-                    }
-                }
+                throw new ArgumentOutOfRangeException(nameof(value), value, "The supplied value is less than the minimum allowed date of 1970-01-01");
             }
         }
 
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DATETIMETYPE"/> class using the specified year, month, day, hour, minute, second, and optional offset.
+        /// </summary>
+        /// <param name="year">The year (1970 - 2037)</param>
+        /// <param name="month">The month of year (1 - 12)</param>
+        /// <param name="day">The day of month (1 - number of days in <see cref="month"/>)</param>
+        /// <param name="hour">The hour of day (0 - 23)</param>
+        /// <param name="minute">The minute of the hour (0-59)</param>
+        /// <param name="second">The second of the minute (0-59)</param>
+        /// <param name="offset">The optional offset from UTC. If no offset is defined, QuickBooks will interpret the date as the local time of the QuickBooks host computer.</param>
+        public DATETIMETYPE(int year, int month, int day, int hour = 0, int minute = 0, int second = 0, TimeSpan? offset = null)
+        {
+            if (year > 2037 || year < 1970) throw new ArgumentOutOfRangeException(nameof(year), year, "Year must be between 1970 and 2037, inclusive");
+
+            _value = new DateTimeOffset(year, month, day, hour, minute, second, offset ?? TimeSpan.Zero);
+            _ignoreOffset = offset == null;
+        }
+
+
+        /// <summary>
+        /// Returns the date in "yyyy-MM-ddTHH:mm:ss" format.
+        /// An offset will be appended if available (+00:00 or -08:00 etc)
+        /// </summary>
         public override string ToString()
         {
-            var k = value.ToString(" K", CultureInfo.InvariantCulture).Trim();
-
-            // QuickBooks doesn't support Z format.
-            if (k == "Z")
-            {
-                k = "+00:00";
-            }
-
-            return value.ToString("yyyy-MM-ddTHH:mm:ss", CultureInfo.InvariantCulture) + k;
+            return _ignoreOffset
+                ? _value.ToString("yyyy-MM-ddTHH:mm:ss", CultureInfo.InvariantCulture)
+                : _value.ToString("yyyy-MM-ddTHH:mm:ssK", CultureInfo.InvariantCulture);
         }
 
+        /// <summary>
+        /// Gets a <see cref="DateTime"/> value of this date.
+        /// </summary>
         public DateTime ToDateTime()
         {
-            return value;
+            if (_ignoreOffset)
+            {
+                return _value.DateTime;
+            }
+
+            if (_isLocal)
+            {
+                return DateTime.SpecifyKind(_value.DateTime, DateTimeKind.Local);
+            }
+
+            if (_value.Offset == TimeSpan.Zero)
+            {
+                return DateTime.SpecifyKind(_value.DateTime, DateTimeKind.Utc);
+            }
+
+            return _value.DateTime;
+        }
+
+        /// <summary>
+        /// If this date has a UTC offset specified. If this value was parsed from a QuickBooks response, the existence
+        /// of an offset will likely depend on if a <see cref="QbXmlResponseOptions.TimeZoneBugFix"/> was configured
+        /// for the <see cref="QbXmlResponseOptions"/>. If the <see cref="QbXmlResponseOptions.TimeZoneBugFix"/>, the offset
+        /// can not be reliable interpreted, so it will be ignored. 
+        /// </summary>
+        public bool HasOffset()
+        {
+            return !_ignoreOffset;
+        }
+
+        /// <summary>
+        /// Gets a <see cref="DateTimeOffset"/> value for this date (will throw if offset not specified).
+        /// Use <see cref="HasOffset"/> to determine if this can be used, otherwise use <see cref="TryGetDateTimeOffset"/>, <see cref="ToDateTime"/>, or <see cref="ToString"/>.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">Throws if an offset is not specified</exception>
+        public DateTimeOffset GetDateTimeOffset()
+        {
+            if (_ignoreOffset)
+            {
+                throw new InvalidOperationException("An offset is not available");
+            }
+
+            return _value;
+        }
+
+        /// <summary>
+        /// Attempts to return a <see cref="DateTimeOffset"/> value for this date.
+        /// </summary>
+        /// <returns>False if offset inforation is not available, and an accurate <see cref="DateTimeOffset"/> cannot be returned</returns> 
+        /// <remarks>
+        /// Offsets are optional when communicating with QuickBooks, and in the case of responses, are often incorrect.
+        /// Because of this, sometimes <see cref="DATETIMETYPE"/> needs to be treated as a <see cref="DateTime"/> and others as a <see cref="DateTimeOffset"/>.
+        /// </remarks>
+        public bool TryGetDateTimeOffset(out DateTimeOffset value)
+        {
+            if (_ignoreOffset)
+            {
+                value = DateTimeOffset.MinValue;
+                return false;
+            }
+
+            value = _value;
+            return true;
         }
 
         public override bool Equals(object obj)
@@ -108,7 +214,8 @@ namespace QbSync.QbXml.Objects
             var objType = obj as DATETIMETYPE;
             if (objType != null)
             {
-                return value == objType.value;
+                return _value == objType._value && 
+                       _ignoreOffset == objType._ignoreOffset;
             }
 
             return base.Equals(obj);
@@ -116,13 +223,13 @@ namespace QbSync.QbXml.Objects
 
         public override int GetHashCode()
         {
-            return value.GetHashCode();
+            return _value.GetHashCode();
         }
 
         public static bool operator ==(DATETIMETYPE a, DATETIMETYPE b)
         {
             // If both are null, or both are same instance, return true.
-            if (System.Object.ReferenceEquals(a, b))
+            if (ReferenceEquals(a, b))
             {
                 return true;
             }
@@ -141,11 +248,15 @@ namespace QbSync.QbXml.Objects
             return !(a == b);
         }
 
+        //TODO: Remove support for implicit casting from system types, as they may throw exceptions
+        [Obsolete("Implicit operators will be no longer supported")]
         public static implicit operator DATETIMETYPE(DateTime value)
         {
             return new DATETIMETYPE(value);
         }
 
+        //TODO: Remove support for implicit casting to system types. User should make a explicit choice to lose data to convert to DateTime
+        [Obsolete("Implicit operators will be no longer supported")]
         public static implicit operator DateTime(DATETIMETYPE type)
         {
             if (type != null)
@@ -156,9 +267,27 @@ namespace QbSync.QbXml.Objects
             return default(DateTime);
         }
 
+
+        public static bool operator <(DATETIMETYPE a, DATETIMETYPE b)
+        {
+            return a.CompareTo(b) < 0;
+        }
+
+        public static bool operator >(DATETIMETYPE a, DATETIMETYPE b)
+        {
+            return a.CompareTo(b) > 0;
+        }
+
         public int CompareTo(DATETIMETYPE other)
         {
-            return this.value.CompareTo(other.value);
+            if (other == null) return 1;
+
+            if (_ignoreOffset || other._ignoreOffset)
+            {
+                return _value.DateTime.CompareTo(other._value.DateTime);
+            }
+
+            return _value.CompareTo(other._value);
         }
 
         public System.Xml.Schema.XmlSchema GetSchema()
@@ -166,15 +295,69 @@ namespace QbSync.QbXml.Objects
             return null;
         }
 
+        [Obsolete]
         public void ReadXml(System.Xml.XmlReader reader)
         {
+            if (!_canReadXml)
+            {
+                //This class needs to be immutable as possible
+                //Only allow this when constructed using the empty constructor to only be used by deserialization
+                throw new InvalidOperationException("This method not to be used by user code");
+            }
+
+            //Only allow ReadXML once to prevent user code from calling this method after deserialized
+            _canReadXml = false;
+
             reader.MoveToContent();
             var isEmptyElement = reader.IsEmptyElement;
             reader.ReadStartElement();
-            if (!isEmptyElement)
+
+            if (isEmptyElement)
             {
-                value = Parse(reader.ReadContentAsString());
-                reader.ReadEndElement();
+                _value = new DateTimeOffset(1970, 1, 1, 0, 0, 0, 0, TimeSpan.Zero);
+                _ignoreOffset = true;
+                return;
+            }
+
+            var str = reader.ReadContentAsString();
+            var timeZone = QbXmlResponse.qbXmlResponseOptionsStatic?.TimeZoneBugFix;
+
+            if (timeZone == null && str != null && str.Length > 19)
+            {
+                //QuickBooks has inaccurate offset values
+                //The DateTime is otherwise accurate (follows DST), but the offset does not follow DST
+                //To accomodate for this, simply ignore the offset portion of the string, but only when parsing from XML
+                str = str.Substring(0, 19);
+            }
+
+            try
+            {
+                _value = ParseValue(str, out _ignoreOffset);
+
+                if (timeZone != null && timeZone.SupportsDaylightSavingTime)
+                {
+                    //QuickBooks always returns the BaseUTC offset
+                    //Verify this matches the returned value so we know the fix is configured correctly
+                    if (timeZone.BaseUtcOffset == _value.Offset)
+                    {
+                        //A time zone was specified, so we can correct the values supplied by QB
+                        var correctedOffset = timeZone.GetUtcOffset(_value.DateTime);
+                        _value = new DateTimeOffset(_value.DateTime, correctedOffset);
+                    }
+                    else
+                    {
+                        _ignoreOffset = true;
+                    }
+                }
+            }
+            catch (Exception)
+            {
+                _value = new DateTimeOffset(1970, 1, 1, 0, 0, 0, 0, TimeSpan.Zero);
+                _ignoreOffset = true;
+            }
+            finally
+            {
+               reader.ReadEndElement();
             }
         }
 
@@ -183,15 +366,67 @@ namespace QbSync.QbXml.Objects
             writer.WriteString(ToString());
         }
 
-        private static DateTime Parse(string value)
+        private static DateTimeOffset ParseValue(string value, out bool isMissingOffset)
         {
-            DateTime output;
-            if (DateTime.TryParse(value, out output))
+            if (value == null)
             {
-                return output;
+                throw new ArgumentNullException(nameof(value));
             }
 
-            return DateTime.MinValue;
+            //Check if the offset is supplied at the end of supplied value
+            isMissingOffset = !Regex.IsMatch(value, "(?:Z|[+-](?:2[0-3]|[01][0-9]):[0-5][0-9])$");
+
+            //According to MSDN: If <Offset> is missing, its default value is the offset of the local time zone.
+            //We assume universal below instead so offset is 0 when not supplied to the time does not get adjusted
+            
+            return DateTimeOffset.Parse(value, DateTimeFormatInfo.InvariantInfo, DateTimeStyles.AssumeUniversal);
         }
+
+
+        /// <summary>
+        /// Parses from a string value. If an offset is not provided in the string, one will not be inferred.
+        /// When no offset is defined, QuickBooks will interpret the date as the local time of the QuickBooks host computer.
+        /// </summary>
+        /// <param name="value">Date string in either "yyyy-MM-ddTHH:mm:ss" or "yyyy-MM-ddTHH:mm:ssK" format (but others may work as well). K is the offset (ie "Z", "-08:00", "+00:00", etc)</param>
+        /// <returns>A new instance of the <see cref="DATETIMETYPE"/> class</returns>
+        /// <exception cref="ArgumentNullException">If <see cref="value"/> is null</exception>
+        /// <exception cref="FormatException">If <see cref="value"/> is in an unsupported format</exception>
+        public static DATETIMETYPE Parse(string value)
+        {
+            if (value == null)
+            {
+                throw new ArgumentNullException(nameof(value));
+            }
+
+            bool ignoreOffset;
+            var date = ParseValue(value, out ignoreOffset);
+
+            return new DATETIMETYPE(date)
+            {
+                _ignoreOffset = ignoreOffset
+            };
+        }
+
+
+        /// <summary>
+        /// The QuickBooks epoch is 2038-01-19T03:14:07+00:00. No date can be higher than this in QuickBooks
+        /// </summary>
+        public static readonly DATETIMETYPE MaxValue = new DATETIMETYPE
+        {
+            _value = new DateTimeOffset(2038, 1, 19, 3, 14, 7, 0, TimeSpan.Zero),
+            _ignoreOffset = false,
+            _canReadXml = false
+        };
+
+        /// <summary>
+        /// Minimum date QuickBooks allows (1970-01-01)
+        /// </summary>
+        public static readonly DATETIMETYPE MinValue = new DATETIMETYPE
+        {
+            _value = new DateTimeOffset(1970, 1, 1, 0, 0, 0, 0, TimeSpan.Zero),
+            _ignoreOffset = true,
+            _canReadXml = false
+        };
+
     }
 }

--- a/src/QbXml/Objects/Types/DATETIMETYPE.cs
+++ b/src/QbXml/Objects/Types/DATETIMETYPE.cs
@@ -37,13 +37,6 @@ namespace QbSync.QbXml.Objects
             }
         }
 
-        [Obsolete("TimeZoneInfo is no longer used. Use static DATETIMETYPE.Parse")]
-        public DATETIMETYPE(string value, TimeZoneInfo timeZoneInfo) 
-            : this(value)
-        {
-        }
-
-
         /// <summary>
         /// Initializes a new instance of the <see cref="DATETIMETYPE"/> class using the specified <see cref="DateTime"/>.
         /// NOTE: The <see cref="DateTime.Kind"/> property of the <see cref="value"/> will be used to determine 
@@ -82,14 +75,6 @@ namespace QbSync.QbXml.Objects
                 throw new ArgumentOutOfRangeException(nameof(value), value, "The supplied value is less than the minimum allowed date of 1970-01-01");
             }
         }
-
-
-        [Obsolete("TimeZoneInfo is no longer used. Use overload without timeZoneInfo")]
-        public DATETIMETYPE(DateTime value, TimeZoneInfo timeZoneInfo)
-            : this (value)
-        {
-        }
-
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DATETIMETYPE"/> class using the specified <see cref="DateTimeOffset"/>.

--- a/src/QbXml/Objects/Types/DATETIMETYPE.cs
+++ b/src/QbXml/Objects/Types/DATETIMETYPE.cs
@@ -122,7 +122,10 @@ namespace QbSync.QbXml.Objects
         /// <param name="offset">The optional offset from UTC. If no offset is defined, QuickBooks will interpret the date as the local time of the QuickBooks host computer.</param>
         public DATETIMETYPE(int year, int month, int day, int hour = 0, int minute = 0, int second = 0, TimeSpan? offset = null)
         {
-            if (year > 2037 || year < 1970) throw new ArgumentOutOfRangeException(nameof(year), year, "Year must be between 1970 and 2037, inclusive");
+            if (year > 2037 || year < 1970)
+            {
+                throw new ArgumentOutOfRangeException(nameof(year), year, "Year must be between 1970 and 2037, inclusive");
+            }
 
             _value = new DateTimeOffset(year, month, day, hour, minute, second, offset ?? TimeSpan.Zero);
             _ignoreOffset = offset == null;
@@ -248,14 +251,14 @@ namespace QbSync.QbXml.Objects
             return !(a == b);
         }
 
-        //TODO: Remove support for implicit casting from system types, as they may throw exceptions
+        // TODO: Remove support for implicit casting from system types, as they may throw exceptions
         [Obsolete("Implicit operators will be no longer supported")]
         public static implicit operator DATETIMETYPE(DateTime value)
         {
             return new DATETIMETYPE(value);
         }
 
-        //TODO: Remove support for implicit casting to system types. User should make a explicit choice to lose data to convert to DateTime
+        // TODO: Remove support for implicit casting to system types. User should make a explicit choice to lose data to convert to DateTime
         [Obsolete("Implicit operators will be no longer supported")]
         public static implicit operator DateTime(DATETIMETYPE type)
         {
@@ -280,7 +283,10 @@ namespace QbSync.QbXml.Objects
 
         public int CompareTo(DATETIMETYPE other)
         {
-            if (other == null) return 1;
+            if (other == null)
+            {
+                return 1;
+            }
 
             if (_ignoreOffset || other._ignoreOffset)
             {
@@ -300,12 +306,12 @@ namespace QbSync.QbXml.Objects
         {
             if (!_canReadXml)
             {
-                //This class needs to be immutable as possible
-                //Only allow this when constructed using the empty constructor to only be used by deserialization
+                // This class needs to be immutable as possible
+                // Only allow this when constructed using the empty constructor to only be used by deserialization
                 throw new InvalidOperationException("This method not to be used by user code");
             }
 
-            //Only allow ReadXML once to prevent user code from calling this method after deserialized
+            // Only allow ReadXML once to prevent user code from calling this method after deserialized
             _canReadXml = false;
 
             reader.MoveToContent();
@@ -324,9 +330,9 @@ namespace QbSync.QbXml.Objects
 
             if (timeZone == null && str != null && str.Length > 19)
             {
-                //QuickBooks has inaccurate offset values
-                //The DateTime is otherwise accurate (follows DST), but the offset does not follow DST
-                //To accomodate for this, simply ignore the offset portion of the string, but only when parsing from XML
+                // QuickBooks has inaccurate offset values
+                // The DateTime is otherwise accurate (follows DST), but the offset does not follow DST
+                // To accomodate for this, simply ignore the offset portion of the string, but only when parsing from XML
                 str = str.Substring(0, 19);
             }
 
@@ -336,11 +342,11 @@ namespace QbSync.QbXml.Objects
 
                 if (timeZone != null && timeZone.SupportsDaylightSavingTime)
                 {
-                    //QuickBooks always returns the BaseUTC offset
-                    //Verify this matches the returned value so we know the fix is configured correctly
+                    // QuickBooks always returns the BaseUTC offset
+                    // Verify this matches the returned value so we know the fix is configured correctly
                     if (timeZone.BaseUtcOffset == _value.Offset)
                     {
-                        //A time zone was specified, so we can correct the values supplied by QB
+                        // A time zone was specified, so we can correct the values supplied by QB
                         var correctedOffset = timeZone.GetUtcOffset(_value.DateTime);
                         _value = new DateTimeOffset(_value.DateTime, correctedOffset);
                     }
@@ -355,10 +361,8 @@ namespace QbSync.QbXml.Objects
                 _value = new DateTimeOffset(1970, 1, 1, 0, 0, 0, 0, TimeSpan.Zero);
                 _ignoreOffset = true;
             }
-            finally
-            {
-               reader.ReadEndElement();
-            }
+
+            reader.ReadEndElement();
         }
 
         public void WriteXml(System.Xml.XmlWriter writer)
@@ -373,11 +377,11 @@ namespace QbSync.QbXml.Objects
                 throw new ArgumentNullException(nameof(value));
             }
 
-            //Check if the offset is supplied at the end of supplied value
+            // Check if the offset is supplied at the end of supplied value
             isMissingOffset = !Regex.IsMatch(value, "(?:Z|[+-](?:2[0-3]|[01][0-9]):[0-5][0-9])$");
 
-            //According to MSDN: If <Offset> is missing, its default value is the offset of the local time zone.
-            //We assume universal below instead so offset is 0 when not supplied to the time does not get adjusted
+            // According to MSDN: If <Offset> is missing, its default value is the offset of the local time zone.
+            // We assume universal below instead so offset is 0 when not supplied to the time does not get adjusted
             
             return DateTimeOffset.Parse(value, DateTimeFormatInfo.InvariantInfo, DateTimeStyles.AssumeUniversal);
         }

--- a/src/QbXml/Objects/Types/DATETIMETYPE.cs
+++ b/src/QbXml/Objects/Types/DATETIMETYPE.cs
@@ -251,26 +251,6 @@ namespace QbSync.QbXml.Objects
             return !(a == b);
         }
 
-        // TODO: Remove support for implicit casting from system types, as they may throw exceptions
-        [Obsolete("Implicit operators will be no longer supported")]
-        public static implicit operator DATETIMETYPE(DateTime value)
-        {
-            return new DATETIMETYPE(value);
-        }
-
-        // TODO: Remove support for implicit casting to system types. User should make a explicit choice to lose data to convert to DateTime
-        [Obsolete("Implicit operators will be no longer supported")]
-        public static implicit operator DateTime(DATETIMETYPE type)
-        {
-            if (type != null)
-            {
-                return type.ToDateTime();
-            }
-
-            return default(DateTime);
-        }
-
-
         public static bool operator <(DATETIMETYPE a, DATETIMETYPE b)
         {
             return a.CompareTo(b) < 0;

--- a/src/QbXml/Objects/Types/DATETIMETYPE.cs
+++ b/src/QbXml/Objects/Types/DATETIMETYPE.cs
@@ -9,15 +9,12 @@ namespace QbSync.QbXml.Objects
     public partial class DATETIMETYPE : ITypeWrapper, IComparable<DATETIMETYPE>, IXmlSerializable
     {
         private DateTimeOffset _value;
-
         private bool _hasOffset;
-        private bool _canReadXml;
         private readonly bool _isLocal;
 
         // Private constructor as only xml deserialization should be using this
         private DATETIMETYPE()
         {
-            _canReadXml = true;
         }
 
         
@@ -39,30 +36,28 @@ namespace QbSync.QbXml.Objects
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DATETIMETYPE"/> class using the specified <see cref="DateTime"/>.
-        /// NOTE: The <see cref="DateTime.Kind"/> property of the <see cref="value"/> will be used to determine 
-        /// if and what offset should be used when sending the value to QuickBooks. 
-        /// <see cref="DateTimeKind"/>.<see cref="DateTimeKind.Utc"/> will use "+00:00".
-        /// <see cref="DateTimeKind"/>.<see cref="DateTimeKind.Local"/> will use the offset as determined by the timezone of the machine this application is running on.
-        /// <see cref="DateTimeKind"/>.<see cref="DateTimeKind.Unspecified"/> will use no offset, which QuickBooks will interpret to mean the local time of the QuickBooks host computer.
+        /// NOTE: The offset from UTC, if any, that will be sent to QuickBooks along with this date depends on the <see cref="DateTime.Kind"/> of the specified <see cref="value"/>.
+        /// <see cref="DateTimeKind"/>.<see cref="DateTimeKind.Utc"/> will send "+00:00".
+        /// <see cref="DateTimeKind"/>.<see cref="DateTimeKind.Local"/> will send an offset as determined by the timezone of the machine this application is running on.
+        /// <see cref="DateTimeKind"/>.<see cref="DateTimeKind.Unspecified"/> will send no offset, which QuickBooks will interpret to mean the local time of the QuickBooks host computer.
         /// </summary>
         /// <seealso cref="DateTimeKind"/>
         public DATETIMETYPE(DateTime value)
         {
-            if (value.Kind == DateTimeKind.Utc)
+            switch (value.Kind)
             {
-                _value = new DateTimeOffset(value, TimeSpan.Zero);
-                _hasOffset = true;
-            }
-            else if (value.Kind == DateTimeKind.Local)
-            {
-                _value = new DateTimeOffset(value);
-                _hasOffset = true;
-                _isLocal = true;
-            }
-            else
-            {
-                _hasOffset = false;
-                _value = new DateTimeOffset(value, TimeSpan.Zero);
+                case DateTimeKind.Utc:
+                    _value = new DateTimeOffset(value, TimeSpan.Zero);
+                    _hasOffset = true;
+                    break;
+                case DateTimeKind.Local:
+                    _value = new DateTimeOffset(value);
+                    _hasOffset = true;
+                    _isLocal = true;
+                    break;
+                default:
+                    _value = new DateTimeOffset(value, TimeSpan.Zero);
+                    break;
             }
 
             if (this > MaxValue)
@@ -78,28 +73,28 @@ namespace QbSync.QbXml.Objects
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DATETIMETYPE"/> class using the specified <see cref="DateTimeOffset"/>.
-        /// <see cref="HasOffset"/> will always be true, and the supplied offset will be included with requests to QuickBooks.
+        /// <see cref="DateTimeOffset.Offset"/> will be included with requests to QuickBooks.
         /// </summary>
         /// <param name="value">The <see cref="DateTimeOffset"/> value</param>
         public DATETIMETYPE(DateTimeOffset value)
         {
-            _value = value;
-            _hasOffset = true;
-
-            if (this > MaxValue)
+            if (value > MaxValue._value)
             {
                 throw new ArgumentOutOfRangeException(nameof(value), value, "The supplied value is greater than the QuickBooks epoch of 2038-01-19T03:14:07+00:00");
             }
 
-            if (this < MinValue)
+            if (value < MinValue._value)
             {
                 throw new ArgumentOutOfRangeException(nameof(value), value, "The supplied value is less than the minimum allowed date of 1970-01-01");
             }
+
+            _value = value;
+            _hasOffset = true;
         }
 
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="DATETIMETYPE"/> class using the specified year, month, day, hour, minute, second, and optional offset.
+        /// Initializes a new instance of the <see cref="DATETIMETYPE"/> class using the specified year, month, day, hour, minute, second, and offset.
         /// </summary>
         /// <param name="year">The year (1970 - 2037)</param>
         /// <param name="month">The month of year (1 - 12)</param>
@@ -107,22 +102,68 @@ namespace QbSync.QbXml.Objects
         /// <param name="hour">The hour of day (0 - 23)</param>
         /// <param name="minute">The minute of the hour (0-59)</param>
         /// <param name="second">The second of the minute (0-59)</param>
-        /// <param name="offset">The optional offset from UTC. If no offset is defined, QuickBooks will interpret the date as the local time of the QuickBooks host computer.</param>
+        /// <param name="offset">The offset from UTC. If no offset is defined, QuickBooks will interpret the date as the local time of the QuickBooks host computer.</param>
         public DATETIMETYPE(int year, int month, int day, int hour = 0, int minute = 0, int second = 0, TimeSpan? offset = null)
         {
-            if (year > 2037 || year < 1970)
+            if (year < 1970)
             {
-                throw new ArgumentOutOfRangeException(nameof(year), year, "Year must be between 1970 and 2037, inclusive");
+                throw new ArgumentOutOfRangeException(nameof(year), year, "Year is less than minimum allowed value of 1970");
             }
 
             _value = new DateTimeOffset(year, month, day, hour, minute, second, offset ?? TimeSpan.Zero);
+
+            if (_value > MaxValue._value)
+            {
+                throw new ArgumentOutOfRangeException(message: "The created date is greater than the QuickBooks epoch of 2038-01-19T03:14:07+00:00", innerException: null);
+            }
+
             _hasOffset = offset != null;
         }
 
 
         /// <summary>
-        /// Returns the date in "yyyy-MM-ddTHH:mm:ss" format.
-        /// An offset will be appended if available (+00:00 or -08:00 etc)
+        /// Get's the time offset from Coordinated Universal Time (UTC), if available
+        /// </summary>
+        public TimeSpan? Offset => _hasOffset ? _value.Offset : (TimeSpan?)null;
+
+        /// <summary>
+        /// Gets the number of ticks for the date
+        /// </summary>
+        public long Ticks => _value.Ticks;
+
+        /// <summary>
+        /// Gets the year component of the date (1970-2038)
+        /// </summary>
+        public int Year => _value.Year;
+
+        /// <summary>
+        /// Gets the month component of the date (1-12)
+        /// </summary>
+        public int Month => _value.Month;
+
+        /// <summary>
+        /// Gets the day of month component of the date (1-31)
+        /// </summary>
+        public int Day => _value.Day;
+
+        /// <summary>
+        /// Gets the hour component of the date (0-23)
+        /// </summary>
+        public int Hour => _value.Hour;
+
+        /// <summary>
+        /// Gets the minute component of the date (0-59)
+        /// </summary>
+        public int Minute => _value.Minute;
+
+        /// <summary>
+        /// Gets the second component of the date (0-59)
+        /// </summary>
+        public int Second => _value.Second;
+
+
+        /// <summary>
+        /// Returns the date in "yyyy-MM-ddTHH:mm:ss[K]" format (The 'K' offset will only be appended if <see cref="Offset"/> is available)
         /// </summary>
         public override string ToString()
         {
@@ -131,10 +172,11 @@ namespace QbSync.QbXml.Objects
                 : _value.ToString("yyyy-MM-ddTHH:mm:ss", CultureInfo.InvariantCulture);
         }
 
+
         /// <summary>
         /// Gets a <see cref="DateTime"/> value of this date.
         /// NOTE: In most cases this will have an <see cref="DateTimeKind.Unspecified"/> <see cref="DateTimeKind"/>.
-        /// Do not use <see cref="DateTime.ToUniversalTime"/> or <see cref="DateTime.ToLocalTime"/> on the returned value. 
+        /// Use of <see cref="DateTime.ToUniversalTime"/> or <see cref="DateTime.ToLocalTime"/> on the returned value is not recommended. 
         /// </summary>
         public DateTime ToDateTime()
         {
@@ -157,21 +199,10 @@ namespace QbSync.QbXml.Objects
         }
 
         /// <summary>
-        /// If this date has a UTC offset specified. If this value was parsed from a QuickBooks response, the existence
-        /// of an offset will likely depend on if a <see cref="QbXmlResponseOptions.TimeZoneBugFix"/> was configured
-        /// for the <see cref="QbXmlResponseOptions"/>. If the <see cref="QbXmlResponseOptions.TimeZoneBugFix"/>, the offset
-        /// can not be reliable interpreted, so it will be ignored. 
+        /// Gets a <see cref="DateTimeOffset"/> value for this date, if <see cref="Offset"/> is available. Will throw a <see cref="InvalidOperationException"/> otherwise.
+        /// Alternatively use <see cref="TryGetDateTimeOffset"/>, which will not throw.
         /// </summary>
-        public bool HasOffset()
-        {
-            return _hasOffset;
-        }
-
-        /// <summary>
-        /// Gets a <see cref="DateTimeOffset"/> value for this date (will throw if offset not specified).
-        /// Use <see cref="HasOffset"/> to determine if this can be used, otherwise use <see cref="TryGetDateTimeOffset"/>, <see cref="ToDateTime"/>, or <see cref="ToString"/>.
-        /// </summary>
-        /// <exception cref="InvalidOperationException">Throws if an offset is not specified</exception>
+        /// <exception cref="InvalidOperationException">Throws if <see cref="Offset"/> is null</exception>
         public DateTimeOffset GetDateTimeOffset()
         {
             if (!_hasOffset)
@@ -185,7 +216,7 @@ namespace QbSync.QbXml.Objects
         /// <summary>
         /// Attempts to return a <see cref="DateTimeOffset"/> value for this date.
         /// </summary>
-        /// <returns>False if offset inforation is not available, and an accurate <see cref="DateTimeOffset"/> cannot be returned</returns> 
+        /// <returns>False if <see cref="Offset"/> is not available, and an accurate <see cref="DateTimeOffset"/> cannot be returned</returns> 
         /// <remarks>
         /// Offsets are optional when communicating with QuickBooks, and in the case of responses, are often incorrect.
         /// Because of this, sometimes <see cref="DATETIMETYPE"/> needs to be treated as a <see cref="DateTime"/> and others as a <see cref="DateTimeOffset"/>.
@@ -270,34 +301,20 @@ namespace QbSync.QbXml.Objects
             return null;
         }
 
-        [Obsolete]
         public void ReadXml(System.Xml.XmlReader reader)
         {
-            if (!_canReadXml)
-            {
-                // This class needs to be immutable as possible
-                // Only allow this when constructed using the empty constructor to only be used by deserialization
-                throw new InvalidOperationException("This method not to be used by user code");
-            }
-
-            // Only allow ReadXML once to prevent user code from calling this method after deserialized
-            _canReadXml = false;
-
-            reader.MoveToContent();
-            var isEmptyElement = reader.IsEmptyElement;
-            reader.ReadStartElement();
-
-            if (isEmptyElement)
+            var str = reader.ReadElementContentAsString();
+            
+            if (string.IsNullOrWhiteSpace(str))
             {
                 _value = MinValue._value;
                 _hasOffset = false;
                 return;
             }
 
-            var str = reader.ReadContentAsString();
-            var timeZone = QbXmlResponse.qbXmlResponseOptionsStatic?.TimeZoneBugFix;
+            var timeZone = QbXmlResponse.qbXmlResponseOptionsStatic?.QuickBooksDesktopTimeZone;
 
-            if (timeZone == null && str != null && str.Length > 19)
+            if (timeZone == null && str.Length > 19)
             {
                 // QuickBooks has inaccurate offset values
                 // The DateTime is otherwise accurate (follows DST), but the offset does not follow DST
@@ -331,8 +348,6 @@ namespace QbSync.QbXml.Objects
                 _value = MinValue._value;
                 _hasOffset = false;
             }
-
-            reader.ReadEndElement();
         }
 
         public void WriteXml(System.Xml.XmlWriter writer)
@@ -358,10 +373,9 @@ namespace QbSync.QbXml.Objects
 
 
         /// <summary>
-        /// Parses from a string value. If an offset is not provided in the string, one will not be inferred.
-        /// When no offset is defined, QuickBooks will interpret the date as the local time of the QuickBooks host computer.
+        /// Parses from a string value. When no offset is included, QuickBooks will interpret the date as the local time of the QuickBooks host computer.
         /// </summary>
-        /// <param name="value">Date string in either "yyyy-MM-ddTHH:mm:ss" or "yyyy-MM-ddTHH:mm:ssK" format (but others may work as well). K is the offset (ie "Z", "-08:00", "+00:00", etc)</param>
+        /// <param name="value">Date string in yyyy-mm-dd[Thh][:mm][:ss][K] format (though other standard formats will work as well). K is the offset from UTC (ie "Z", "-08:00", "+00:00", etc)</param>
         /// <returns>A new instance of the <see cref="DATETIMETYPE"/> class</returns>
         /// <exception cref="ArgumentNullException">If <see cref="value"/> is null</exception>
         /// <exception cref="FormatException">If <see cref="value"/> is in an unsupported format</exception>
@@ -382,13 +396,52 @@ namespace QbSync.QbXml.Objects
 
 
         /// <summary>
-        /// The QuickBooks epoch is 2038-01-19T03:14:07+00:00. No date can be higher than this in QuickBooks
+        /// Parses from a string value. If the <see cref="value"/> cannot be parsed, the provided <see cref="defaultValue"/> will be returned.
+        /// If an offset from Coordinated Universal Time (UTC) is missing, QuickBooks will interpret the date as the local time of the QuickBooks host computer.
+        /// </summary>
+        /// <param name="value">Date string in yyyy-mm-dd[Thh][:mm][:ss][K] format (though other standard formats will work as well). K is the offset from UTC (ie "Z", "-08:00", "+00:00", etc)</param>
+        /// <param name="defaultValue">The default value to use if parsing is unsuccessful</param>
+        /// <returns>A new instance of <see cref="DATETIMETYPE"/>, or <see cref="defaultValue"/></returns>
+        public static DATETIMETYPE ParseOrDefault(string value, DATETIMETYPE defaultValue = default(DATETIMETYPE))
+        {
+            if (TryParse(value, out var result))
+            {
+                return result;
+            }
+
+            return defaultValue;
+        }
+
+
+        /// <summary>
+        /// Tries to parse <see cref="DATETIMETYPE"/> from a string. If an offset is not provided in the string, one will not be inferred.
+        /// When no offset is defined, QuickBooks will interpret the date as the local time of the QuickBooks host computer.
+        /// </summary>
+        /// <param name="value">Date string in yyyy-mm-dd[Thh][:mm][:ss][K] format (though other standard formats will work as well). K is the offset from UTC (ie "Z", "-08:00", "+00:00", etc)</param>
+        /// <param name="date">If parsing was successful, the new instance of <see cref="DATETIMETYPE"/>, otherwise null</param>
+        /// <returns>True is parsing was successful</returns>
+        public static bool TryParse(string value, out DATETIMETYPE date)
+        {
+            try
+            {
+                date = Parse(value);
+                return true;
+            }
+            catch
+            {
+                date = null;
+                return false;
+            }
+        }
+
+
+        /// <summary>
+        /// The QuickBooks max value for a date & time is 2038-01-19T03:14:07+00:00
         /// </summary>
         public static readonly DATETIMETYPE MaxValue = new DATETIMETYPE
         {
             _value = new DateTimeOffset(2038, 1, 19, 3, 14, 7, 0, TimeSpan.Zero),
             _hasOffset = true,
-            _canReadXml = false
         };
 
         /// <summary>
@@ -398,8 +451,6 @@ namespace QbSync.QbXml.Objects
         {
             _value = new DateTimeOffset(1970, 1, 1, 0, 0, 0, 0, TimeSpan.Zero),
             _hasOffset = false,
-            _canReadXml = false
         };
-
     }
 }

--- a/src/QbXml/QbXmlResponseOptions.cs
+++ b/src/QbXml/QbXmlResponseOptions.cs
@@ -9,21 +9,37 @@ namespace QbSync.QbXml
     public class QbXmlResponseOptions
     {
         /// <summary>
-        /// Used to interpret UTC offsets on <see cref="DATETIMETYPE"/> values returned from QuickBooks.
-        /// Set this value to the time zone of the QuickBooks host machine so UTC offsets returned
-        /// from QuickBooks will be corrected. If null, returned offsets will be ignored.
+        /// Used to interpret the UTC offset of <see cref="DATETIMETYPE"/> values returned in QuickBooks responses.
+        /// When [accurately] set, <see cref="DATETIMETYPE.Offset"/> will be populated for <see cref="DATETIMETYPE"/>
+        /// values returned from QuickBooks, and <see cref="DATETIMETYPE.GetDateTimeOffset"/> can be used.
         ///
-        /// If a <see cref="TimeZoneBugFix"/> zone is specified, offsets may still be ignored if
-        /// the zone is not accurate for the QuickBooks host machine. Offsets returned from
-        /// QuickBooks requiring more correction than the max <see cref="TimeZoneInfo.AdjustmentRule.DaylightDelta"/>
-        /// for the adjustment rules for that zone are ignored.
+        /// If a <see cref="TimeZoneInfo"/> is not set, or the <see cref="TimeZoneInfo.BaseUtcOffset"/> does not match the
+        /// values returned from QuickBooks, the UTC <see cref="DATETIMETYPE.Offset"/> will be null, and the date
+        /// cannot be converted to UTC or a UTC based value. 
         /// </summary>
         /// <remarks>
-        /// The UTC offset portion of dates returned from QuickBooks do not follow
-        /// DST rules, and always follow the "Base Offset" for the zone.
-        /// Without knowing the time zone of the client computer QuickBooks
-        /// is running on, the offset can not be accurately interpreted. 
+        /// The reason this option exists is because of the issue that QuickBooks has with regards to handling DST.
+        /// The Date & time components of returned dates follow DST rules, but the offset always represents standard time.
+        /// This means during daylight saving time, the offset will be an hour off (for most DST enabled time zones at least).
+        /// Because  different time zones have different DST deltas, and change to/from DST at different times, the
+        /// actual offset for a date cannot be determined unless the time zone of the host computer is known.
+        ///
+        /// However, because offsets are optional in QuickBooks date range queries, we can use the values as returned from QuickBooks
+        /// with the offset component removed, and subsequent requests to QuickBooks with this value will work as expected
+        /// because QuickBooks will interpret the date & time as in the local time it's host computer.
         /// </remarks>
-        public TimeZoneInfo TimeZoneBugFix { get; set; }
+        public TimeZoneInfo QuickBooksDesktopTimeZone { get; set; }
+
+        /// <summary>
+        /// While the QuickBooks bug is still an issue, how it is handled has slightly changed so
+        /// implementing this fix can be optional now. In turn, this method has been renamed
+        /// to better match the updated implementation. 
+        /// </summary>
+        [Obsolete("This has been renamed to QuickBooksDesktopTimeZone")]
+        public TimeZoneInfo TimeZoneBugFix
+        {
+            get => QuickBooksDesktopTimeZone;
+            set => QuickBooksDesktopTimeZone = value;
+        }
     }
 }

--- a/src/QbXml/QbXmlResponseOptions.cs
+++ b/src/QbXml/QbXmlResponseOptions.cs
@@ -26,7 +26,7 @@ namespace QbSync.QbXml
         ///
         /// However, because offsets are optional in QuickBooks date range queries, we can use the values as returned from QuickBooks
         /// with the offset component removed, and subsequent requests to QuickBooks with this value will work as expected
-        /// because QuickBooks will interpret the date & time as in the local time it's host computer.
+        /// because QuickBooks will interpret the date & time as being in the local zone of its host computer.
         /// </remarks>
         public TimeZoneInfo QuickBooksDesktopTimeZone { get; set; }
 

--- a/src/QbXml/QbXmlResponseOptions.cs
+++ b/src/QbXml/QbXmlResponseOptions.cs
@@ -2,17 +2,28 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using QbSync.QbXml.Objects;
 
 namespace QbSync.QbXml
 {
     public class QbXmlResponseOptions
     {
         /// <summary>
-        /// Used to fix all dates provided by QuickBooks.
-        /// The Date in QuickBooks are not correct when the DST is in effect on the
-        /// client computer. If the date returned by QuickBooks is within a DST range,
-        /// we will substract the offset appropriately.
+        /// Used to interpret UTC offsets on <see cref="DATETIMETYPE"/> values returned from QuickBooks.
+        /// Set this value to the time zone of the QuickBooks host machine so UTC offsets returned
+        /// from QuickBooks will be corrected. If null, returned offsets will be ignored.
+        ///
+        /// If a <see cref="TimeZoneBugFix"/> zone is specified, offsets may still be ignored if
+        /// the zone is not accurate for the QuickBooks host machine. Offsets returned from
+        /// QuickBooks requiring more correction than the max <see cref="TimeZoneInfo.AdjustmentRule.DaylightDelta"/>
+        /// for the adjustment rules for that zone are ignored.
         /// </summary>
+        /// <remarks>
+        /// The UTC offset portion of dates returned from QuickBooks do not follow
+        /// DST rules, and always follow the "Base Offset" for the zone.
+        /// Without knowing the time zone of the client computer QuickBooks
+        /// is running on, the offset can not be accurately interpreted. 
+        /// </remarks>
         public TimeZoneInfo TimeZoneBugFix { get; set; }
     }
 }

--- a/test/QbXml.Tests/Messages/Responses/CustomerQueryResponseTests.cs
+++ b/test/QbXml.Tests/Messages/Responses/CustomerQueryResponseTests.cs
@@ -79,7 +79,7 @@ namespace QbSync.QbXml.Tests.QbXml
 
             var response = new QbXmlResponse(new QbXmlResponseOptions
             {
-                TimeZoneBugFix = QuickBooksTestHelper.GetPacificStandardTimeZoneInfo()
+                QuickBooksDesktopTimeZone = QuickBooksTestHelper.GetPacificStandardTimeZoneInfo()
             });
             var rs = response.GetSingleItemFromResponse<CustomerQueryRsType>(QuickBooksTestHelper.CreateQbXmlWithEnvelope(ret, "CustomerQueryRs"));
             var customers = rs.CustomerRet;

--- a/test/QbXml.Tests/Messages/Responses/CustomerQueryResponseTests.cs
+++ b/test/QbXml.Tests/Messages/Responses/CustomerQueryResponseTests.cs
@@ -85,7 +85,9 @@ namespace QbSync.QbXml.Tests.QbXml
             var customers = rs.CustomerRet;
             var customer = customers[0];
 
-            Assert.AreEqual(17, customer.TimeModified.ToDateTime().ToUniversalTime().Hour);
+            Assert.AreEqual(10, customer.TimeModified.ToDateTime().Hour);
+            Assert.AreEqual(10, customer.TimeModified.GetDateTimeOffset().Hour);
+            Assert.AreEqual(-7, customer.TimeModified.GetDateTimeOffset().Offset.Hours);
         }
 
         [Test]

--- a/test/QbXml.Tests/Types/DateTimeTypeTests.cs
+++ b/test/QbXml.Tests/Types/DateTimeTypeTests.cs
@@ -2,67 +2,591 @@
 using QbSync.QbXml.Objects;
 using QbSync.QbXml.Tests.Helpers;
 using System;
+using System.IO;
+using System.Xml;
 
 namespace QbSync.QbXml.Tests.Types
 {
     [TestFixture]
     public class DateTimeTypeTests
     {
-        [Test]
-        public void DateTimeWithDSTNothingHappensWhenNoTimzoneSupplied()
+        [TestCase("2015-04-03T10:06:17-08:00", ExpectedResult = "2015-04-03T10:06:17-08:00")]
+        [TestCase("2015-04-03T10:06:17-07:00", ExpectedResult = "2015-04-03T10:06:17-07:00")]
+        [TestCase("2015-04-03T10:06:17Z", ExpectedResult = "2015-04-03T10:06:17+00:00", Description = "UTC Z offset format will change to +00:00")]
+        [TestCase("2015-04-03T10:06:17", ExpectedResult = "2015-04-03T10:06:17", Description = "UTC Offset is optional")]
+        public string ToStringOffsetExistenceMatchesInputWhenParsingFromString(string input)
         {
-            var dt = new DATETIMETYPE("2015-04-03T10:06:17-08:00");
+            return DATETIMETYPE.Parse(input).ToString();
+        }
 
-            Assert.AreEqual(18, dt.ToDateTime().ToUniversalTime().Hour);
+        [TestCase("2015-04-03T10:06:17-08:00", ExpectedResult = "2015-04-03T10:06:17-08:00")]
+        [TestCase("2015-04-03T10:06:17-07:00", ExpectedResult = "2015-04-03T10:06:17-07:00")]
+        [TestCase("2015-04-03T10:06:17Z", ExpectedResult = "2015-04-03T10:06:17+00:00", Description = "UTC Z offset format will change to +00:00")]
+        [TestCase("2015-04-03T10:06:17", ExpectedResult = "2015-04-03T10:06:17", Description = "UTC Offset is optional")]
+        public string ToStringOffsetExistenceMatchesInputWhenConstructingFromString(string input)
+        {
+#pragma warning disable 618
+            return new DATETIMETYPE(input).ToString();
+#pragma warning restore 618
         }
 
         [Test]
-        public void DateTimeWithDSTIsNotHandledByQuickBooks()
+        public void ToStringDoesNotIncludeOffsetWhenConstructedFromUnspecifiedDateTime()
         {
-            // This should read 2015-04-03T10:06:17-07:00
-            // But QuickBooks does not handle DST. So we need to handle it ourself.
-            var dt = new DATETIMETYPE("2015-04-03T10:06:17-08:00", QuickBooksTestHelper.GetPacificStandardTimeZoneInfo());
+            var date = new DateTime(2019, 2, 6, 17, 24, 0, DateTimeKind.Unspecified);
+            var dt = new DATETIMETYPE(date);
 
-            Assert.AreEqual(17, dt.ToDateTime().ToUniversalTime().Hour);
+            Assert.AreEqual("2019-02-06T17:24:00", dt.ToString());
         }
 
         [Test]
-        public void DateTimeWithNoDSTIsNotHandledByQuickBooks()
+        public void ToStringDoesIncludesOffsetWhenConstructedFromUtcDateTime()
         {
-            var dt = new DATETIMETYPE("2015-03-01T10:06:17-08:00", QuickBooksTestHelper.GetPacificStandardTimeZoneInfo());
+            var date = new DateTime(2019, 2, 6, 17, 24, 0, DateTimeKind.Utc);
+            var dt = new DATETIMETYPE(date);
 
-            Assert.AreEqual(18, dt.ToDateTime().ToUniversalTime().Hour);
+            Assert.AreEqual("2019-02-06T17:24:00+00:00", dt.ToString());
         }
 
         [Test]
-        public void DateTimeInvalidSentByQuickBooks()
+        public void ToStringDoesIncludesOffsetWhenConstructedFromLocalDateTime()
         {
-            var dt = new DATETIMETYPE("0000-00-00", QuickBooksTestHelper.GetPacificStandardTimeZoneInfo());
+            var date = new DateTime(2019, 2, 6, 17, 24, 0, DateTimeKind.Local);
 
-            Assert.AreEqual(DateTime.MinValue, dt.ToDateTime());
+            //Note, this will be +00:00, not Z on a UTC machine, because of DateTimeKind.Local
+            var offset = date.ToString(" K").Trim(); 
+
+            var dt = new DATETIMETYPE(date);
+
+            Assert.AreEqual($"2019-02-06T17:24:00{offset}", dt.ToString());
         }
 
         [Test]
-        [Ignore("We can't have this test on a machine other than PST? Is there a way to fix this easily.")]
-        public void DateTimeLocalToString()
+        public void MidnightIsAssumedIfTimeComponentMissing()
         {
-            var utcDateTime = new DateTime(2015, 4, 3, 10, 6, 17, DateTimeKind.Utc);
-            var timeZoneInfo = QuickBooksTestHelper.GetPacificStandardTimeZoneInfo();
-            var localDateTime = TimeZoneInfo.ConvertTime(utcDateTime, timeZoneInfo);
-            localDateTime = DateTime.SpecifyKind(localDateTime, DateTimeKind.Local);
+            var dt = DATETIMETYPE.Parse("2019-02-06");
+            var date = dt.ToDateTime();
 
-            var dt = new DATETIMETYPE(localDateTime);
-
-            Assert.AreEqual("2015-04-03T03:06:17-07:00", dt.ToString());
+            Assert.AreEqual("2019-02-06T00:00:00", dt.ToString());
+            Assert.AreEqual(new DateTime(2019, 2, 6, 0, 0, 0), date);
         }
 
         [Test]
-        public void DateTimeUtcToString()
+        public void UsesOffsetAsSuppliedWhenConstructedFromDateTimeOffset()
         {
-            var utcDateTime = new DateTime(2015, 4, 3, 10, 6, 17, DateTimeKind.Utc);
-            var dt = new DATETIMETYPE(utcDateTime);
+            var dt = new DATETIMETYPE(new DateTimeOffset(2019, 2, 6, 17, 24, 0, TimeSpan.FromHours(-8)));
 
-            Assert.AreEqual("2015-04-03T10:06:17+00:00", dt.ToString());
+            Assert.AreEqual("2019-02-06T17:24:00-08:00", dt.ToString());
         }
+
+        [Test]
+        public void UsesOffsetAsSuppliedWhenConstructedFromDateComponents()
+        {
+            var dt = new DATETIMETYPE(2019, 2, 6, 17, 24, 0, TimeSpan.FromHours(-8));
+
+            Assert.AreEqual("2019-02-06T17:24:00-08:00", dt.ToString());
+        }
+
+        [Test]
+        public void UsesNoOffsetWhenConstructedFromDateComponentsWithNullOffset()
+        {
+            var dt = new DATETIMETYPE(2019, 2, 6, 17, 24, 0, null);
+
+            Assert.AreEqual("2019-02-06T17:24:00", dt.ToString());
+        }
+
+#pragma warning disable 618
+        [Test]
+        public void ObsoleteImplicitCastFromDateTime()
+        {
+            DATETIMETYPE dt = new DateTime(2019, 2, 6, 17, 24, 0, DateTimeKind.Unspecified);
+            Assert.AreEqual("2019-02-06T17:24:00", dt.ToString());
+        }
+
+        [Test]
+        public void ObsoleteExplicitCastFromDateTime()
+        {
+            var dt = (DATETIMETYPE)new DateTime(2019, 2, 6, 17, 24, 0, DateTimeKind.Unspecified);
+            Assert.AreEqual("2019-02-06T17:24:00", dt.ToString());
+        }
+#pragma warning restore 618
+
+        [Test]
+        public void CompareAccountsForOffset()
+        {
+            //A's instant (moment in time globally) is later, but its DateTime is earlier
+            var a = new DATETIMETYPE(new DateTimeOffset(2019, 1, 1, 6, 0, 0, 0, TimeSpan.FromHours(-3)));
+
+            //B's instant is earlier, but its DateTime is later
+            var b = new DATETIMETYPE(new DateTimeOffset(2019, 1, 1, 8, 0, 0, 0, TimeSpan.Zero));
+
+            Assert.AreEqual(1, a.CompareTo(b));
+        }
+
+        [Test]
+        public void CompareIgnoresOffsetWhenOneDoNotHaveOffset()
+        {
+            var a = new DATETIMETYPE(new DateTimeOffset(2019, 1, 1, 8, 0, 0, 0, TimeSpan.FromHours(-10)));
+            var b = new DATETIMETYPE(new DateTime(2019, 1, 1, 8, 0, 0, 0, DateTimeKind.Unspecified));
+
+            Assert.AreEqual(0, a.CompareTo(b));
+        }
+
+        [Test]
+        public void EqualsOperatorSameInstance()
+        {
+            var a = new DATETIMETYPE(2019, 1, 1);
+            var b = a;
+
+            Assert.IsTrue(a == b);
+        }
+
+        [Test]
+        public void EqualsOperatorSameValue()
+        {
+            var a = new DATETIMETYPE(2019, 1, 1);
+            var b = new DATETIMETYPE(2019, 1, 1);
+
+            Assert.IsTrue(a == b);
+        }
+
+        [Test]
+        public void EqualsOperatorSameValueDifferentConstruction()
+        {
+            var a = new DATETIMETYPE(2019, 1, 1);
+            var b = new DATETIMETYPE(new DateTime(2019, 1, 1));
+
+            Assert.IsTrue(a == b);
+        }
+
+        [Test]
+        public void EqualsOperatorBothNull()
+        {
+            DATETIMETYPE a = null;
+            DATETIMETYPE b = null;
+
+            Assert.IsTrue(a == b);
+        }
+
+        [Test]
+        public void EqualsOperatorLeftNull()
+        {
+            DATETIMETYPE a = null;
+            DATETIMETYPE b = new DATETIMETYPE(2019, 1, 1);
+
+            Assert.IsFalse(a == b);
+        }
+
+        [Test]
+        public void EqualsOperatorRightNull()
+        {
+            DATETIMETYPE a = new DATETIMETYPE(2019, 1, 1);
+            DATETIMETYPE b = null;
+
+            Assert.IsFalse(a == b);
+        }
+
+        [Test]
+        public void EqualsSameInstantDifferentOffsets()
+        {
+            //Even though these are two different offsets, they represent the same moment in time and both have offsets supplied, so should be equal
+
+            var a = new DATETIMETYPE(2019, 1, 1, 12, 0, 0, TimeSpan.FromHours(-1));
+            var b = new DATETIMETYPE(2019, 1, 1, 11, 0, 0, TimeSpan.FromHours(-2));
+
+            Assert.AreEqual(0, a.CompareTo(b));
+            Assert.IsTrue(a.Equals(b));
+        }
+
+        [Test]
+        public void EqualsOperatorSameInstantDifferentOffsets()
+        {
+            //Even though these are two different offsets, they represent the same moment in time and both have offsets supplied, so should be equal
+
+            var a = new DATETIMETYPE(2019, 1, 1, 12, 0, 0, TimeSpan.FromHours(-1));
+            var b = new DATETIMETYPE(2019, 1, 1, 11, 0, 0, TimeSpan.FromHours(-2));
+
+            Assert.AreEqual(0, a.CompareTo(b));
+            Assert.IsTrue(a == b);
+        }
+
+        [Test]
+        public void EqualsOperatorSameTimeOneMissingOffset()
+        {
+            //While these will compare the same, they should not be considered equal
+
+            var a = new DATETIMETYPE(new DateTimeOffset(2019, 1, 1, 8, 0, 0, 0, TimeSpan.Zero));
+            var b = new DATETIMETYPE(new DateTime(2019, 1, 1, 8, 0, 0, 0, DateTimeKind.Unspecified));
+
+            Assert.AreEqual(0, a.CompareTo(b));
+            Assert.IsFalse(a == b);
+        }
+
+        private static DATETIMETYPE[] ToDateTimeIsUtcForZeroOffsetsInput()
+        {
+            return new[]
+            {
+                DATETIMETYPE.Parse("2019-02-06T17:24:00Z"),
+                DATETIMETYPE.Parse("2019-02-06T17:24:00+00:00"),
+                new DATETIMETYPE(new DateTime(2019, 1, 1, 8, 0, 0, 0, DateTimeKind.Utc)),
+                new DATETIMETYPE(new DateTimeOffset(2019, 2, 6, 17, 24, 0, TimeSpan.Zero)),
+            };
+        }
+
+        [Test, TestCaseSource(nameof(ToDateTimeIsUtcForZeroOffsetsInput))]
+        public void ToDateTimeIsUtcForZeroOffsets(DATETIMETYPE input)
+        {
+            Assert.AreEqual(DateTimeKind.Utc, input.ToDateTime().Kind);
+        }
+
+
+        private static DATETIMETYPE[] ToDateTimeIsUnspecifiedForNonZeroAndEmptyOffsetsInputs()
+        {
+            return new[]
+            {
+                DATETIMETYPE.Parse("2019-02-06T17:24:00"),
+                DATETIMETYPE.Parse("2019-02-07T17:24:00-08:00"),
+                new DATETIMETYPE(new DateTime(2019, 1, 1, 8, 0, 0, 0, DateTimeKind.Unspecified)),
+                new DATETIMETYPE(new DateTimeOffset(2019, 2, 9, 17, 24, 0, TimeSpan.FromHours(-8)))
+            };
+        }
+
+        [Test, TestCaseSource(nameof(ToDateTimeIsUnspecifiedForNonZeroAndEmptyOffsetsInputs))]
+        public void ToDateTimeIsUnspecifiedForNonZeroAndEmptyOffsets(DATETIMETYPE input)
+        {
+            Assert.AreEqual(DateTimeKind.Unspecified, input.ToDateTime().Kind);
+        }
+
+        [Test]
+        public void ToDateTimeIsLocalKindWhenConstructedFromLocalDateTime()
+        {
+            //This situation only covers when a consumer of this library is converting back to DateTime after initializing from DateTime
+            //No QuickBooks parsed DATETIMETYPE will ever have a Local kind
+
+            var dt = new DATETIMETYPE(new DateTime(2019, 1, 1, 8, 0, 0, 0, DateTimeKind.Local));
+            Assert.AreEqual(DateTimeKind.Local, dt.ToDateTime().Kind);
+        }
+
+        [Test]
+        public void ToDateTimeEqualsInputWhenConstructedFromLocalDateTime()
+        {
+            var input = new DateTime(2018, 8, 1, 0, 0, 0, DateTimeKind.Local);
+            var dt = new DATETIMETYPE(input);
+            var output = dt.ToDateTime();
+
+            Assert.AreEqual(input, output);
+        }
+
+        [Test]
+        public void OffsetMatchesLocalMachineZoneWhenConstructedFromLocalDateTime()
+        {
+            var localDate = new DateTime(2019, 1, 1, 8, 0, 0, 0, DateTimeKind.Local);
+            var zone = TimeZoneInfo.Local;
+            var offset = zone.GetUtcOffset(localDate);
+
+            var dt = new DATETIMETYPE(new DateTime(2019, 1, 1, 8, 0, 0, 0, DateTimeKind.Local));
+
+            Assert.AreEqual(offset, dt.GetDateTimeOffset().Offset);
+        }
+
+
+        [Test]
+        public void GetDateTimeOffsetThrowsWhenNoOffset()
+        {
+            var dt = DATETIMETYPE.Parse("2019-02-06T17:24:00");
+            Assert.Throws<InvalidOperationException>(() => dt.GetDateTimeOffset());
+        }
+
+        [Test]
+        public void GetDateTimeOffsetReturnsSameValue()
+        {
+            var dto = new DateTimeOffset(2019, 2, 6, 17, 24, 0, TimeSpan.FromHours(-8));
+            var dt = new DATETIMETYPE(dto);
+
+            Assert.AreEqual(dto, dt.GetDateTimeOffset());
+        }
+
+        [Test]
+        public void LessThanOperator()
+        {
+            var a = new DATETIMETYPE(new DateTimeOffset(2019, 1, 1, 8, 0, 0, TimeSpan.Zero));
+            var b = new DATETIMETYPE(new DateTimeOffset(2019, 1, 1, 9, 0, 0, TimeSpan.Zero));
+
+            Assert.IsTrue(a < b);
+        }
+
+        [Test]
+        public void GreaterThanOperator()
+        {
+            var a = new DATETIMETYPE(new DateTimeOffset(2019, 1, 1, 8, 0, 0, TimeSpan.Zero));
+            var b = new DATETIMETYPE(new DateTimeOffset(2019, 1, 1, 9, 0, 0, TimeSpan.Zero));
+
+            Assert.IsTrue(b > a);
+        }
+
+
+        [Test]
+        public void ThrowsWhenConstructedWithDateTimeAfterEpoch()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+            {
+                var date = new DATETIMETYPE(new DateTime(2038, 2, 1, 0, 0, 0));
+            });
+        }
+
+        [Test]
+        public void ThrowsWhenConstructedWithDateTimeBefore1970()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+            {
+                var date = new DATETIMETYPE(new DateTime(1969, 12, 31, 23, 59, 59));
+            });
+        }
+
+        [Test]
+        public void ThrowsWhenConstructedWithDateTimeOffsetAfterEpoch()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+            {
+                var date = new DATETIMETYPE(new DateTimeOffset(2038, 2, 1, 0, 0, 0, TimeSpan.Zero));
+            });
+        }
+
+        [Test]
+        public void ThrowsWhenConstructedWithDateTimeOffsetBefore1970()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+            {
+                var date = new DATETIMETYPE(new DateTimeOffset(1969, 12, 31, 23, 59, 59, TimeSpan.Zero));
+            });
+        }
+
+        [Test]
+        public void ThrowsWhenConstructedWithYearOn2038()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+            {
+                var date = new DATETIMETYPE(2038, 1, 1);
+            });
+        }
+
+        [Test]
+        public void ThrowsWhenConstructedWithYearBefore1970()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+            {
+                var date = new DATETIMETYPE(1969, 12, 31, 23, 59, 59);
+            });
+        }
+
+        [Test]
+        public void DoesNotThrowWhenConstructedWithLastDayOf2037()
+        {
+            Assert.DoesNotThrow(() =>
+            {
+                var date = new DATETIMETYPE(2037, 12, 31, 23, 59, 59);
+            });
+        }
+
+        [Test]
+        public void DoesNotThrowWhenConstructedWithFirstDayOf1970()
+        {
+            Assert.DoesNotThrow(() =>
+            {
+                var date = new DATETIMETYPE(1970, 01, 01, 0, 0, 0);
+            });
+        }
+
+        [Test]
+        public void DoesNotThrowWhenConstructedWithFirstDayOf1970AndOffset()
+        {
+            Assert.DoesNotThrow(() =>
+            {
+                var date = new DATETIMETYPE(1970, 01, 01, 0, 0, 0, TimeSpan.Zero);
+            });
+        }
+
+        [Test]
+        public void DoesNotThrowWhenConstructedWithDateTimeOffsetOnEpoch()
+        {
+            Assert.DoesNotThrow(() =>
+            {
+                var date = new DATETIMETYPE(new DateTimeOffset(2038, 1, 19, 3, 14, 7, 0, TimeSpan.Zero));
+            });
+        }
+
+        [Test]
+        public void ThrowsWhenParsedFromStringAfterQbEpoch()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+            {
+                var dt = DATETIMETYPE.Parse("2038-01-19T03:14:08+00:00");
+            });
+        }
+
+        [Test]
+        public void DoesNotThrowWhenParsedFromStringOnQbEpoch()
+        {
+            Assert.DoesNotThrow(() =>
+            {
+                var dt = DATETIMETYPE.Parse("2038-01-19T03:14:07+00:00");
+            });
+        }
+
+        [TestCase("0000-00-00")]
+        [TestCase("0000-00-00T00:00:00")]
+        [TestCase("")]
+        public void ThrowsFormatExceptionWhenInvalidStringIsParsed(string dateString)
+        {
+            Assert.Throws<FormatException>(() =>
+            {
+                var dt = DATETIMETYPE.Parse(dateString);
+            });
+        }
+
+        [Test]
+        public void ThrowsExceptionWhenNullStringIsParsed()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+            {
+                var dt = DATETIMETYPE.Parse(null);
+            });
+        }
+
+
+        private static DATETIMETYPE[] ReadXmlThrowsInputs()
+        {
+            //Return one DATETIMETYPE for each construction method
+
+            return new[]
+            {
+                new DATETIMETYPE(2019, 1, 1),
+                new DATETIMETYPE(new DateTime(2019, 1, 2)),
+                new DATETIMETYPE(new DateTimeOffset(2019, 1, 3, 0, 0, 0, TimeSpan.Zero)),
+                DATETIMETYPE.Parse("2019-01-04T00:00:00")
+            };
+        }
+
+        [Test, TestCaseSource(nameof(ReadXmlThrowsInputs))]
+        public void ReadXmlThrows(DATETIMETYPE date)
+        {
+            //IXmlSerializable requires ReadXML, which makes the class difficult to make immutable
+            //To ensure as much immutability as possible, only let the deserializer use ReadXML
+
+            var reader = XmlReader.Create(new MemoryStream());
+
+            Assert.Throws<InvalidOperationException>(() =>
+            {
+                date.ReadXml(reader);
+            });
+        }
+
+
+        #region QuickBooks parsing and fixes
+
+        private CustomerRet CreateAndParseCustomerQueryXml(string timeCreated, string timeModified, TimeZoneInfo quickBooksTimeZone = null)
+        {
+            var ret = $"<CustomerRet><ListID>80000001-1422671082</ListID><TimeCreated>{timeCreated}</TimeCreated><TimeModified>{timeModified}</TimeModified><EditSequence>1422671082</EditSequence><Name>Chris Curtis</Name><FullName>Christopher Curtis</FullName><IsActive>true</IsActive></CustomerRet>";
+
+            var response = new QbXmlResponse(new QbXmlResponseOptions
+            {
+                TimeZoneBugFix = quickBooksTimeZone
+            });
+            var rs = response.GetSingleItemFromResponse<CustomerQueryRsType>(QuickBooksTestHelper.CreateQbXmlWithEnvelope(ret, "CustomerQueryRs"));
+            return rs.CustomerRet[0];
+        }
+
+
+        [Test]
+        public void OffsetIsIgnoreWhenXmlParsed()
+        {
+            //This tests the QuickBooks fix that simply ignores the returned offset portion of the date [when no fix applied]
+
+            var time = "2015-04-03T10:06:17-07:00";
+
+            var customer = CreateAndParseCustomerQueryXml(time, time);
+
+            Assert.AreEqual("2015-04-03T10:06:17", customer.TimeModified.ToString());
+        }
+
+        [Test]
+        public void IncorrectOffsetReturnedFromQuickBooksDoesNotAlterParsedTime()
+        {
+            var incorrectOffset = "2015-04-03T10:06:17-08:00";
+            var correctOffset = "2015-04-03T10:06:17-07:00";
+
+            var customer = CreateAndParseCustomerQueryXml(timeCreated: incorrectOffset, timeModified: correctOffset);
+
+            Assert.AreEqual("2015-04-03T10:06:17", customer.TimeCreated.ToString());
+            Assert.AreEqual("2015-04-03T10:06:17", customer.TimeModified.ToString());
+        }
+
+        [Test]
+        public void DateTimeOnXmlParsedDateIsUnspecifiedKind()
+        {
+            var time = "2015-04-03T10:06:17-08:00";
+
+            var customer = CreateAndParseCustomerQueryXml(time, time);
+
+            Assert.AreEqual(DateTimeKind.Unspecified, customer.TimeModified.ToDateTime().Kind);
+        }
+
+        [Test]
+        public void OffsetIsSetToTimeZoneCorrectValueWhenXmlParsedWithTimeZoneFix()
+        {
+            var time = "2015-04-03T10:06:17-08:00";
+
+            var customer = CreateAndParseCustomerQueryXml(time, time, QuickBooksTestHelper.GetPacificStandardTimeZoneInfo());
+
+            Assert.AreEqual("2015-04-03T10:06:17-07:00", customer.TimeModified.ToString());
+        }
+
+        [Test]
+        public void OffsetIsRetainedWhenXmlParsedForNonDstTimeZoneFix()
+        {
+
+            var time = "2015-04-03T10:06:17+00:00";
+
+            var customer = CreateAndParseCustomerQueryXml(time, time, TimeZoneInfo.Utc);
+
+            Assert.AreEqual("2015-04-03T10:06:17+00:00", customer.TimeModified.ToString());
+        }
+
+        [Test]
+        public void OffsetIsIgnoredWhenXmlParsedAndTimeZoneFixBaseOffsetDoesNotMatchInput()
+        {
+            //A protection against misconfiguration if the time zone is set completely wrong
+
+            var time = "2015-04-03T10:06:17-10:00";
+
+            var customer = CreateAndParseCustomerQueryXml(time, time, QuickBooksTestHelper.GetPacificStandardTimeZoneInfo());
+
+            Assert.AreEqual("2015-04-03T10:06:17", customer.TimeModified.ToString());
+        }
+
+        [Test]
+        public void DefaultDateTimeUsedWhenXmlParsedWithInvalidDate()
+        {
+            //Dates have been seen with 0000-00-00. Need to use default date instead of throwing
+
+            var time = "0000-00-00";
+
+            var customer = CreateAndParseCustomerQueryXml(time, time);
+
+            Assert.AreEqual("1970-01-01T00:00:00", customer.TimeModified.ToString());
+        }
+
+        [Test]
+        public void DefaultDateTimeUsedWhenXmlParsedWithEmptyDate()
+        {
+            var time = "";
+
+            var customer = CreateAndParseCustomerQueryXml(time, time);
+
+            Assert.AreEqual("1970-01-01T00:00:00", customer.TimeModified.ToString());
+        }
+
+
+        #endregion
     }
 }

--- a/test/QbXml.Tests/Types/DateTimeTypeTests.cs
+++ b/test/QbXml.Tests/Types/DateTimeTypeTests.cs
@@ -165,22 +165,6 @@ namespace QbSync.QbXml.Tests.Types
             Assert.AreEqual("2019-02-06T17:24:00", dt.ToString());
         }
 
-#pragma warning disable 618
-        [Test]
-        public void ObsoleteImplicitCastFromDateTime()
-        {
-            DATETIMETYPE dt = new DateTime(2019, 2, 6, 17, 24, 0, DateTimeKind.Unspecified);
-            Assert.AreEqual("2019-02-06T17:24:00", dt.ToString());
-        }
-
-        [Test]
-        public void ObsoleteExplicitCastFromDateTime()
-        {
-            var dt = (DATETIMETYPE)new DateTime(2019, 2, 6, 17, 24, 0, DateTimeKind.Unspecified);
-            Assert.AreEqual("2019-02-06T17:24:00", dt.ToString());
-        }
-#pragma warning restore 618
-
         [Test]
         public void CompareAccountsForOffset()
         {

--- a/test/QbXml.Tests/Types/DateTimeTypeTests.cs
+++ b/test/QbXml.Tests/Types/DateTimeTypeTests.cs
@@ -31,6 +31,76 @@ namespace QbSync.QbXml.Tests.Types
         }
 
         [Test]
+        public void RoundTripsAsExpectedWithoutTimeZoneFix()
+        {
+            // Simulated value returned from QuickBooks, that we want to be sent the exact same way to future queries
+            var str = "2019-02-20T10:36:51";
+            var date = DATETIMETYPE.Parse(str);
+
+            // DATETIMETYPE > string
+            Assert.AreEqual(str, date.ToString());
+
+            // DATETIMETYPE > string > DATETIMETYPE > string
+            Assert.AreEqual(str, DATETIMETYPE.Parse(date.ToString()).ToString());
+
+            // DATETIMETYPE > DateTime > DATETIMETYPE > string
+            Assert.AreEqual(str, new DATETIMETYPE(date.ToDateTime()).ToString());
+
+            // DATETIMETYPE > DateTime > string > DATETIMETYPE > string
+            Assert.AreEqual(str, DATETIMETYPE.Parse(date.ToDateTime().ToString()).ToString());
+
+            // DATETIMETYPE > DateTime > string > DateTime > DATETIMETYPE > string
+            Assert.AreEqual(str, new DATETIMETYPE(DateTime.Parse(date.ToDateTime().ToString())).ToString());
+        }
+
+        [Test]
+        public void RoundTripsAsExpectedWithTimeZoneFix()
+        {
+            // Simulated value returned from QuickBooks, that we want to be sent the exact same way to future queries
+            var date = DATETIMETYPE.Parse("2019-02-20T10:36:51-08:00");
+
+            // DATETIMETYPE > string
+            Assert.AreEqual("2019-02-20T10:36:51-08:00", date.ToString());
+
+            // DATETIMETYPE > string > DATETIMETYPE > string
+            Assert.AreEqual("2019-02-20T10:36:51-08:00", DATETIMETYPE.Parse(date.ToString()).ToString());
+
+
+            // *********************************************************************************
+            // NOTE:
+            // These next tests make use of DateTimeOffset, which is only available for
+            // QuickBooks parsed values if a time zone fix is in place.
+            // Offset is kept throughout in these cases
+            // *********************************************************************************
+
+            // DATETIMETYPE > DateTimeOffset > DATETIMETYPE > string
+            Assert.AreEqual("2019-02-20T10:36:51-08:00", new DATETIMETYPE(date.GetDateTimeOffset()).ToString());
+
+            // DATETIMETYPE > DateTimeOffset > string > DATETIMETYPE > string
+            Assert.AreEqual("2019-02-20T10:36:51-08:00", DATETIMETYPE.Parse(date.GetDateTimeOffset().ToString()).ToString());
+
+            // DATETIMETYPE > DateTimeOffset > string > DateTimeOffset > DATETIMETYPE > string
+            Assert.AreEqual("2019-02-20T10:36:51-08:00", new DATETIMETYPE(DateTimeOffset.Parse(date.GetDateTimeOffset().ToString())).ToString());
+
+
+            // *********************************************************************************
+            // NOTE:
+            // The rest of these tests convert to DateTime. We'll lose offset information.
+            // That is OK as long as the time component does not change
+            // *********************************************************************************
+
+            // DATETIMETYPE > DateTime > DATETIMETYPE > string
+            Assert.AreEqual("2019-02-20T10:36:51", new DATETIMETYPE(date.ToDateTime()).ToString());
+
+            // DATETIMETYPE > DateTime > string > DATETIMETYPE > string
+            Assert.AreEqual("2019-02-20T10:36:51", DATETIMETYPE.Parse(date.ToDateTime().ToString()).ToString());
+
+            // DATETIMETYPE > DateTime > string > DateTime > DATETIMETYPE > string
+            Assert.AreEqual("2019-02-20T10:36:51", new DATETIMETYPE(DateTime.Parse(date.ToDateTime().ToString())).ToString());
+        }
+
+
+        [Test]
         public void ToStringDoesNotIncludeOffsetWhenConstructedFromUnspecifiedDateTime()
         {
             var date = new DateTime(2019, 2, 6, 17, 24, 0, DateTimeKind.Unspecified);

--- a/test/QbXml.Tests/Types/DateTimeTypeTests.cs
+++ b/test/QbXml.Tests/Types/DateTimeTypeTests.cs
@@ -53,7 +53,7 @@ namespace QbSync.QbXml.Tests.Types
         {
             var date = new DateTime(2019, 2, 6, 17, 24, 0, DateTimeKind.Local);
 
-            //Note, this will be +00:00, not Z on a UTC machine, because of DateTimeKind.Local
+            // Note, this will be +00:00, not Z on a UTC machine, because of DateTimeKind.Local
             var offset = date.ToString(" K").Trim(); 
 
             var dt = new DATETIMETYPE(date);
@@ -114,10 +114,10 @@ namespace QbSync.QbXml.Tests.Types
         [Test]
         public void CompareAccountsForOffset()
         {
-            //A's instant (moment in time globally) is later, but its DateTime is earlier
+            // A's instant (moment in time globally) is later, but its DateTime is earlier
             var a = new DATETIMETYPE(new DateTimeOffset(2019, 1, 1, 6, 0, 0, 0, TimeSpan.FromHours(-3)));
 
-            //B's instant is earlier, but its DateTime is later
+            // B's instant is earlier, but its DateTime is later
             var b = new DATETIMETYPE(new DateTimeOffset(2019, 1, 1, 8, 0, 0, 0, TimeSpan.Zero));
 
             Assert.AreEqual(1, a.CompareTo(b));
@@ -189,7 +189,7 @@ namespace QbSync.QbXml.Tests.Types
         [Test]
         public void EqualsSameInstantDifferentOffsets()
         {
-            //Even though these are two different offsets, they represent the same moment in time and both have offsets supplied, so should be equal
+            // Even though these are two different offsets, they represent the same moment in time and both have offsets supplied, so should be equal
 
             var a = new DATETIMETYPE(2019, 1, 1, 12, 0, 0, TimeSpan.FromHours(-1));
             var b = new DATETIMETYPE(2019, 1, 1, 11, 0, 0, TimeSpan.FromHours(-2));
@@ -201,7 +201,7 @@ namespace QbSync.QbXml.Tests.Types
         [Test]
         public void EqualsOperatorSameInstantDifferentOffsets()
         {
-            //Even though these are two different offsets, they represent the same moment in time and both have offsets supplied, so should be equal
+            // Even though these are two different offsets, they represent the same moment in time and both have offsets supplied, so should be equal
 
             var a = new DATETIMETYPE(2019, 1, 1, 12, 0, 0, TimeSpan.FromHours(-1));
             var b = new DATETIMETYPE(2019, 1, 1, 11, 0, 0, TimeSpan.FromHours(-2));
@@ -213,7 +213,7 @@ namespace QbSync.QbXml.Tests.Types
         [Test]
         public void EqualsOperatorSameTimeOneMissingOffset()
         {
-            //While these will compare the same, they should not be considered equal
+            // While these will compare the same, they should not be considered equal
 
             var a = new DATETIMETYPE(new DateTimeOffset(2019, 1, 1, 8, 0, 0, 0, TimeSpan.Zero));
             var b = new DATETIMETYPE(new DateTime(2019, 1, 1, 8, 0, 0, 0, DateTimeKind.Unspecified));
@@ -260,8 +260,8 @@ namespace QbSync.QbXml.Tests.Types
         [Test]
         public void ToDateTimeIsLocalKindWhenConstructedFromLocalDateTime()
         {
-            //This situation only covers when a consumer of this library is converting back to DateTime after initializing from DateTime
-            //No QuickBooks parsed DATETIMETYPE will ever have a Local kind
+            // This situation only covers when a consumer of this library is converting back to DateTime after initializing from DateTime
+            // No QuickBooks parsed DATETIMETYPE will ever have a Local kind
 
             var dt = new DATETIMETYPE(new DateTime(2019, 1, 1, 8, 0, 0, 0, DateTimeKind.Local));
             Assert.AreEqual(DateTimeKind.Local, dt.ToDateTime().Kind);
@@ -456,7 +456,7 @@ namespace QbSync.QbXml.Tests.Types
 
         private static DATETIMETYPE[] ReadXmlThrowsInputs()
         {
-            //Return one DATETIMETYPE for each construction method
+            // Return one DATETIMETYPE for each construction method
 
             return new[]
             {
@@ -470,14 +470,16 @@ namespace QbSync.QbXml.Tests.Types
         [Test, TestCaseSource(nameof(ReadXmlThrowsInputs))]
         public void ReadXmlThrows(DATETIMETYPE date)
         {
-            //IXmlSerializable requires ReadXML, which makes the class difficult to make immutable
-            //To ensure as much immutability as possible, only let the deserializer use ReadXML
+            // IXmlSerializable requires ReadXML, which makes the class difficult to make immutable
+            // To ensure as much immutability as possible, only let the deserializer use ReadXML
 
             var reader = XmlReader.Create(new MemoryStream());
 
             Assert.Throws<InvalidOperationException>(() =>
             {
+#pragma warning disable 612
                 date.ReadXml(reader);
+#pragma warning restore 612
             });
         }
 
@@ -500,7 +502,7 @@ namespace QbSync.QbXml.Tests.Types
         [Test]
         public void OffsetIsIgnoreWhenXmlParsed()
         {
-            //This tests the QuickBooks fix that simply ignores the returned offset portion of the date [when no fix applied]
+            // This tests the QuickBooks fix that simply ignores the returned offset portion of the date [when no fix applied]
 
             var time = "2015-04-03T10:06:17-07:00";
 
@@ -555,7 +557,7 @@ namespace QbSync.QbXml.Tests.Types
         [Test]
         public void OffsetIsIgnoredWhenXmlParsedAndTimeZoneFixBaseOffsetDoesNotMatchInput()
         {
-            //A protection against misconfiguration if the time zone is set completely wrong
+            // A protection against misconfiguration if the time zone is set completely wrong
 
             var time = "2015-04-03T10:06:17-10:00";
 
@@ -567,7 +569,7 @@ namespace QbSync.QbXml.Tests.Types
         [Test]
         public void DefaultDateTimeUsedWhenXmlParsedWithInvalidDate()
         {
-            //Dates have been seen with 0000-00-00. Need to use default date instead of throwing
+            // Dates have been seen with 0000-00-00. Need to use default date instead of throwing
 
             var time = "0000-00-00";
 

--- a/test/WebApplication.Sample/Application/Steps/CustomerQuery.cs
+++ b/test/WebApplication.Sample/Application/Steps/CustomerQuery.cs
@@ -30,7 +30,7 @@ namespace WebApplication.Sample.Application.Steps
             {
                 // By default, we return 100, let's do 5 here.
                 request.MaxReturned = "5";
-                request.FromModifiedDate = new DATETIMETYPE(new DateTime(2019, 4, 28, 0, 55, 40, DateTimeKind.Utc));
+                request.FromModifiedDate = new DATETIMETYPE(2019, 4, 28, 0, 55, 40);
 
                 return base.ExecuteRequestAsync(authenticatedTicket, request);
             }

--- a/test/WebApplication.Sample/Application/WebConnectorHandler.cs
+++ b/test/WebApplication.Sample/Application/WebConnectorHandler.cs
@@ -21,11 +21,12 @@ namespace WebApplication.Sample.Application
 
         public override Task<QbXmlResponseOptions> GetOptionsAsync(IAuthenticatedTicket authenticatedTicket)
         {
-            // You should return a TimeZoneInfo based on the authenticated ticket.
+            // If you want to have UTC offsets included in timestamps returned from QuickBooks
+            // you should return a TimeZoneInfo based on the authenticated ticket.
             // The timezone where the user is running their QuickBooks.
             return Task.FromResult(new QbXmlResponseOptions
             {
-                TimeZoneBugFix = TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time")
+                QuickBooksDesktopTimeZone = TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time")
             });
         }
 

--- a/test/WebConnector.Tests/Impl/StepQueryResponseWithIteratorTests.cs
+++ b/test/WebConnector.Tests/Impl/StepQueryResponseWithIteratorTests.cs
@@ -117,7 +117,7 @@ namespace QbSync.WebConnector.Tests.Impl
             var ret = await stepQueryResponseWithIteratorMock.Object.ReceiveXMLAsync(authenticatedTicket, xml, string.Empty, string.Empty);
             Assert.AreEqual(0, ret);
 
-            //The time zone fix should leave the time as is, and correct the offset according to the provided zone
+            // The time zone fix should leave the time as is, and correct the offset according to the provided zone
             var expectedHour = 10;
             var expectedOffset = TimeSpan.FromHours(-7);
 
@@ -166,7 +166,7 @@ namespace QbSync.WebConnector.Tests.Impl
             Assert.AreEqual(0, ret);
 
 
-            //When there is no time zone fix, the time should be left alone, and the offset should be ignored
+            // When there is no time zone fix, the time should be left alone, and the offset should be ignored
 
             var expectedHour = 10;
             stepQueryResponseWithIteratorMock

--- a/test/WebConnector.Tests/Impl/StepQueryResponseWithIteratorTests.cs
+++ b/test/WebConnector.Tests/Impl/StepQueryResponseWithIteratorTests.cs
@@ -116,10 +116,14 @@ namespace QbSync.WebConnector.Tests.Impl
 
             var ret = await stepQueryResponseWithIteratorMock.Object.ReceiveXMLAsync(authenticatedTicket, xml, string.Empty, string.Empty);
             Assert.AreEqual(0, ret);
-            var expectedHour = 17;
+
+            //The time zone fix should leave the time as is, and correct the offset according to the provided zone
+            var expectedHour = 10;
+            var expectedOffset = TimeSpan.FromHours(-7);
+
             stepQueryResponseWithIteratorMock
                 .Protected()
-                .Verify("ExecuteResponseAsync", Times.Once(), ItExpr.IsAny<AuthenticatedTicket>(), ItExpr.Is<CustomerQueryRsType>(m => m.CustomerRet[0].TimeModified.ToDateTime().ToUniversalTime().Hour == expectedHour));
+                .Verify("ExecuteResponseAsync", Times.Once(), ItExpr.IsAny<AuthenticatedTicket>(), ItExpr.Is<CustomerQueryRsType>(m => m.CustomerRet[0].TimeModified.GetDateTimeOffset().Hour == expectedHour && m.CustomerRet[0].TimeModified.GetDateTimeOffset().Offset == expectedOffset));
         }
 
         [Test]
@@ -160,10 +164,18 @@ namespace QbSync.WebConnector.Tests.Impl
 
             var ret = await stepQueryResponseWithIteratorMock.Object.ReceiveXMLAsync(authenticatedTicket, xml, string.Empty, string.Empty);
             Assert.AreEqual(0, ret);
-            var expectedHour = 18;
+
+
+            //When there is no time zone fix, the time should be left alone, and the offset should be ignored
+
+            var expectedHour = 10;
             stepQueryResponseWithIteratorMock
                 .Protected()
-                .Verify("ExecuteResponseAsync", Times.Once(), ItExpr.IsAny<AuthenticatedTicket>(), ItExpr.Is<CustomerQueryRsType>(m => m.CustomerRet[0].TimeModified.ToDateTime().ToUniversalTime().Hour == expectedHour));
+                .Verify("ExecuteResponseAsync", Times.Once(), ItExpr.IsAny<AuthenticatedTicket>(), ItExpr.Is<CustomerQueryRsType>(m => m.CustomerRet[0].TimeModified.ToDateTime().Hour == expectedHour));
+
+            stepQueryResponseWithIteratorMock
+                .Protected()
+                .Verify("ExecuteResponseAsync", Times.Once(), ItExpr.IsAny<AuthenticatedTicket>(), ItExpr.Is<CustomerQueryRsType>(m => m.CustomerRet[0].TimeModified.HasOffset() == false));
         }
     }
 }

--- a/test/WebConnector.Tests/Impl/StepQueryResponseWithIteratorTests.cs
+++ b/test/WebConnector.Tests/Impl/StepQueryResponseWithIteratorTests.cs
@@ -103,7 +103,7 @@ namespace QbSync.WebConnector.Tests.Impl
 
             var qbXmlResponseOptions = new QbXmlResponseOptions
             {
-                TimeZoneBugFix = QuickBooksTestHelper.GetPacificStandardTimeZoneInfo()
+                QuickBooksDesktopTimeZone = QuickBooksTestHelper.GetPacificStandardTimeZoneInfo()
             };
 
             var stepQueryResponseWithIteratorMock = new Mock<StepQueryResponseBase<CustomerQueryRsType>>();
@@ -175,7 +175,7 @@ namespace QbSync.WebConnector.Tests.Impl
 
             stepQueryResponseWithIteratorMock
                 .Protected()
-                .Verify("ExecuteResponseAsync", Times.Once(), ItExpr.IsAny<AuthenticatedTicket>(), ItExpr.Is<CustomerQueryRsType>(m => m.CustomerRet[0].TimeModified.HasOffset() == false));
+                .Verify("ExecuteResponseAsync", Times.Once(), ItExpr.IsAny<AuthenticatedTicket>(), ItExpr.Is<CustomerQueryRsType>(m => m.CustomerRet[0].TimeModified.Offset == null));
         }
     }
 }


### PR DESCRIPTION
I made some significant changes to `DATETIMETYPE` to have it inherently handle the UTC offset bug, even without a `TimeZoneBugFix` set (though still supported), as well as honor the behavior of the built in `DateTime` type as best I could. I made a few breaking changes where I thought it was critical, but as few as possible, marking `Obsolete` in other situations. 

I included LOTS of tests, and also verified that all tests work in multiple time zones, including UTC. 

#### QB testing results that predicated these changes
It appears that the `DATETIMETYPE` values returned from QuickBooks have correct times, it is just the UTC offset that is incorrect [This was already established, but wanted to confirm]. Seems they just always append the `BaseUtcOffset` for the local time zone of the QuickBooks host computer.

I tested query requests using dates without an offset, and QuickBooks interpreted that value as the local time of the host computer (This matches what their documentation says).  

Combining this together, I tested using the value as returned from quickbooks with the offset ignored to query a date range. My test customer had a `TimeModified` reported from QuickBooks of `2018-08-01T16:05:45-08:00`. This should have been `-07:00` for this date in my time zone (Pacific), A query with range `2018-08-01T16:05:00` to `2018-08-01T16:06:00` returned the same result.

#### Basic summary of changes

To most easily handle the offset issue, DATETIMETYPE needed to handle parsing the dates without the offset, as well as being able to query without an offset, so the same returned value could be used in a query.

- `DATETIMETYPE` now has an option offset. If no `TimeZoneBugFix` is specified, or it is parsed from a string without an offset, No offset will be included.
- Handling of the offset correction has been moved to `ReadXml`, since this is only an issue when reading from QuickBooks. Constructors with `TimeZoneInfo` have been deprecated.
- Added support for construction using a `DateTimeOffset`
- Added range validation (1970 - 2038)
- Deprecated implicit cast from `DateTime`, since a `ArgumentOutOfRangeException` may be thrown
- Deprecated implicit cast to `DateTime`, since there is a loss of data
- `ToDateTime()` returns date with correct `DateTimeKind` depending on the situation (generally `DateTimeKind.Unspecified`)
- Deprecated construction from a string, in favor of static `Parse` method
- A bunch of other things, but I'll let the code and tests speak for the rest

_NOTE: If you like these changes, and think you want to accept them, the other `TYPE` classes should probably also be updated to have similar style and usage, which I can do before you merge if you want_