### PR TITLE
Add public properties to the DATETYPE object.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: csharp
 mono: latest
+dist: trusty
 sudo: required
 dotnet: 2.0.3
 solution: QuickbooksSync.sln

--- a/src/QbXml/Objects/Types/DATETYPE.cs
+++ b/src/QbXml/Objects/Types/DATETYPE.cs
@@ -37,6 +37,31 @@ namespace QbSync.QbXml.Objects
         }
 
         /// <summary>
+        /// Gets the original raw string value parsed from QuickBooks. Will be null if not deserialized from XML.
+        /// </summary>
+        public string QuickBooksRawString { get; private set; }
+
+        /// <summary>
+        /// Gets the number of ticks for the date.
+        /// </summary>
+        public long Ticks => _value.Ticks;
+
+        /// <summary>
+        /// Gets the year component of the date (1970-2038).
+        /// </summary>
+        public int Year => _value.Year;
+
+        /// <summary>
+        /// Gets the month component of the date (1-12).
+        /// </summary>
+        public int Month => _value.Month;
+
+        /// <summary>
+        /// Gets the day of month component of the date (1-31).
+        /// </summary>
+        public int Day => _value.Day;
+
+        /// <summary>
         /// A string representation of the date.
         /// </summary>
         /// <returns>Date in yyyy-MM-dd format.</returns>
@@ -166,7 +191,8 @@ namespace QbSync.QbXml.Objects
             reader.ReadStartElement();
             if (!isEmptyElement)
             {
-                _value = Parse(reader.ReadContentAsString());
+                QuickBooksRawString = reader.ReadContentAsString();
+                _value = Parse(QuickBooksRawString);
                 reader.ReadEndElement();
             }
         }


### PR DESCRIPTION
We serialize the request and response objects to QB for debugging purposes, until now if you would send a TimeTracking object the TxnDate would be blank:
```
	"TimeTrackingRet": [
		{
			"TxnID": "70-1552405893",
			"TimeCreated": {
				"QuickBooksRawString": "2019-03-12T09:51:33-07:00",
				"UncorrectedDate": "2019-03-12T09:51:33-07:00",
				"Ticks": 636879810930000000,
				"Year": 2019,
				"Month": 3,
				"Day": 12,
				"Hour": 9,
				"Minute": 51,
				"Second": 33
			},
			"TxnDate": {},
		}
```

I added a few public properties to the DATETYPE object, similar to the DATETIMETYPE object so that when serializing the object it would come out as:
```
	"TimeTrackingRet": [
		{
			"TxnID": "70-1552405893",
			"TimeCreated": {
				"QuickBooksRawString": "2019-03-12T09:51:33-07:00",
				"UncorrectedDate": "2019-03-12T09:51:33-07:00",
				"Ticks": 636879810930000000,
				"Year": 2019,
				"Month": 3,
				"Day": 12,
				"Hour": 9,
				"Minute": 51,
				"Second": 33
			},
			"TxnDate": {
				"QuickBooksRawString": "2019-03-12",
				"Ticks": 636879456000000000,
				"Year": 2019,
				"Month": 3,
				"Day": 12
			},
		}
```