### PR TITLE
Add common interfaces for most *Ret types

### DIFF
--- a/src/QbXml/Objects/IQbAddress.cs
+++ b/src/QbXml/Objects/IQbAddress.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace QbSync.QbXml.Objects
+﻿namespace QbSync.QbXml.Objects
 {
     public interface IQbAddress : IQbAddressBlock
     {

--- a/src/QbXml/Objects/IQbAddress.cs
+++ b/src/QbXml/Objects/IQbAddress.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace QbSync.QbXml.Objects
+{
+    public interface IQbAddress : IQbAddressBlock
+    {
+        string City { get; set; }
+        string State { get; set; }
+        string PostalCode { get; set; }
+        string Country { get; set; }
+        string Addr1 { get; set; }
+    }
+}

--- a/src/QbXml/Objects/IQbAddressBlock.cs
+++ b/src/QbXml/Objects/IQbAddressBlock.cs
@@ -1,0 +1,11 @@
+﻿namespace QbSync.QbXml.Objects
+{
+    public interface IQbAddressBlock
+    {
+        string Addr1 { get; set; }
+        string Addr2 { get; set; }
+        string Addr3 { get; set; }
+        string Addr4 { get; set; }
+        string Addr5 { get; set; }
+    }
+}

--- a/src/QbXml/Objects/IQbCommInfo.cs
+++ b/src/QbXml/Objects/IQbCommInfo.cs
@@ -1,0 +1,15 @@
+﻿namespace QbSync.QbXml.Objects
+{
+    public interface IQbCommInfo
+    {
+        string Phone { get; set; }
+        string Mobile { get; set; }
+        string Pager { get; set; }
+        string AltPhone { get; set; }
+        string Fax { get; set; }
+        string Email { get; set; }
+        string Cc { get; set; }
+        string Contact { get; set; }
+        string AltContact { get; set; }
+    }
+}

--- a/src/QbXml/Objects/IQbContactInfo.cs
+++ b/src/QbXml/Objects/IQbContactInfo.cs
@@ -1,0 +1,11 @@
+﻿namespace QbSync.QbXml.Objects
+{
+    public interface IQbContactInfo
+    {
+        string Salutation { get; set; }
+        string FirstName { get; set; }
+        string MiddleName { get; set; }
+        string LastName { get; set; }
+        string JobTitle { get; set; }
+    }
+}

--- a/src/QbXml/Objects/IQbListRet.cs
+++ b/src/QbXml/Objects/IQbListRet.cs
@@ -1,0 +1,10 @@
+﻿namespace QbSync.QbXml.Objects
+{
+    /// <summary>
+    /// Interface for common properties to all QuickBooks List ret objects.
+    /// </summary>
+    public interface IQbListRet : IQbRet
+    {
+        string ListID { get; }
+    }
+}

--- a/src/QbXml/Objects/IQbPersonName.cs
+++ b/src/QbXml/Objects/IQbPersonName.cs
@@ -1,0 +1,11 @@
+﻿namespace QbSync.QbXml.Objects
+{
+    public interface IQbPersonName
+    {
+        string Salutation { get; set; }
+        string FirstName { get; set; }
+        string MiddleName { get; set; }
+        string LastName { get; set; }
+        string Suffix { get; set; }
+    }
+}

--- a/src/QbXml/Objects/IQbRequest.cs
+++ b/src/QbXml/Objects/IQbRequest.cs
@@ -5,5 +5,6 @@
     /// </summary>
     public interface IQbRequest
     {
+        string requestID { get; set; }
     }
 }

--- a/src/QbXml/Objects/IQbResponse.cs
+++ b/src/QbXml/Objects/IQbResponse.cs
@@ -26,5 +26,17 @@ namespace QbSync.QbXml.Objects
         /// </summary>
         string statusSeverity { get; set; }
     }
+
+    /// <summary>
+    /// An interface indicating if the class is a response.
+    /// </summary>
+    /// <typeparam name="TResultRet">The *Ret result object type included in the response</typeparam>
+    public interface IQbResponse<out TResultRet> : IQbResponse
+    {
+        /// <summary>
+        /// Gets the value of the *Ret result object from the response.
+        /// </summary>
+        TResultRet GetRetResult();
+    }
 }
 #pragma warning restore IDE1006

--- a/src/QbXml/Objects/IQbRet.cs
+++ b/src/QbXml/Objects/IQbRet.cs
@@ -1,0 +1,14 @@
+﻿namespace QbSync.QbXml.Objects
+{
+    /// <summary>
+    /// Interface for common properties to all QuickBooks ret objects.
+    /// </summary>
+    public interface IQbRet
+    {
+        DATETIMETYPE TimeCreated { get; }
+        
+        DATETIMETYPE TimeModified { get; }
+        
+        string EditSequence { get; }
+    }
+}

--- a/src/QbXml/Objects/IQbTxnRet.cs
+++ b/src/QbXml/Objects/IQbTxnRet.cs
@@ -1,0 +1,14 @@
+﻿namespace QbSync.QbXml.Objects
+{
+    /// <summary>
+    /// Interface for common properties to all QuickBooks Txn ret objects.
+    /// </summary>
+    public interface IQbTxnRet : IQbRet
+    {
+        string TxnID { get; }
+        
+        string TxnNumber { get; }
+        
+        DATETYPE TxnDate { get; }
+    }
+}

--- a/src/XsdGenerator/MemberEnhancer.cs
+++ b/src/XsdGenerator/MemberEnhancer.cs
@@ -151,6 +151,31 @@ namespace QbSync.XsdGenerator
                 {
                     codeType.BaseTypes.Add("IQbTxnRet");
                 }
+
+                if (items.OfType<XmlSchemaGroupRef>().Any(x => new []{ "AddressData", "ShipToAddressData" }.Contains(x.RefName?.Name)))
+                {
+                    codeType.BaseTypes.Add("IQbAddress");
+                }
+
+                if (items.OfType<XmlSchemaGroupRef>().Any(x => x.RefName?.Name == "AddressBlockData"))
+                {
+                    codeType.BaseTypes.Add("IQbAddressBlock");
+                }
+
+                if (items.OfType<XmlSchemaGroupRef>().Any(x => x.RefName?.Name == "ContactInfo"))
+                {
+                    codeType.BaseTypes.Add("IQbContactInfo");
+                }
+
+                if (items.OfType<XmlSchemaGroupRef>().Any(x => x.RefName?.Name == "CommInfo"))
+                {
+                    codeType.BaseTypes.Add("IQbCommInfo");
+                }
+
+                if (items.OfType<XmlSchemaGroupRef>().Any(x => x.RefName?.Name == "PersonName"))
+                {
+                    codeType.BaseTypes.Add("IQbPersonName");
+                }
             }
 
             var missingTxnRets = new[]

--- a/src/XsdGenerator/MemberEnhancer.cs
+++ b/src/XsdGenerator/MemberEnhancer.cs
@@ -138,6 +138,31 @@ namespace QbSync.XsdGenerator
             {
                 codeType.BaseTypes.Add("IQbIteratorResponse");
             }
+
+            var complexType = GetXmlSchemaComplexType();
+            if (complexType?.Particle?.GetType().GetProperty("Items")?.GetValue(complexType.Particle) is XmlSchemaObjectCollection items)
+            {
+                if (items.OfType<XmlSchemaGroupRef>().Any(x => x.RefName?.Name == "ListCore"))
+                {
+                    codeType.BaseTypes.Add("IQbListRet");
+                }
+
+                if (items.OfType<XmlSchemaGroupRef>().Any(x => x.RefName?.Name == "TxnCore"))
+                {
+                    codeType.BaseTypes.Add("IQbTxnRet");
+                }
+            }
+
+            var missingTxnRets = new[]
+            {
+                "ReceivePaymentRet",
+                "ARRefundCreditCardRet"
+            };
+
+            if (missingTxnRets.Contains(codeType.Name))
+            {
+                codeType.BaseTypes.Add("IQbTxnRet");
+            }
         }
 
         private void RemoveFields(string[] fields)


### PR DESCRIPTION
Adds `IQbListRet` and `IQbTxnRet` interfaces, with a common `IQbRet` interface between them. `MemberEnhancer` and `TypeEnahcner` are modified to add inheritance of these interface to the *Ret types accordingly during generation from XSD.

Also adds an additional generic version of `IQbResponse` that provides an interface level method to retrieve the *Ret object from a response. The non-generic version is inherited, making this a non-breaking change.