### PR TITLE
Bug fix for TransactionTypeFilter generated property type

### DIFF
--- a/src/XsdGenerator/MemberEnhancer.cs
+++ b/src/XsdGenerator/MemberEnhancer.cs
@@ -665,9 +665,9 @@ namespace QbSync.XsdGenerator
                 {
                     isArray = true;
                 }
-                else if (xmlSchemaElement.Parent as XmlSchemaChoice != null)
+                else if (xmlSchemaElement.Parent is XmlSchemaChoice parent)
                 {
-                    isArray = (xmlSchemaElement.Parent as XmlSchemaChoice).MaxOccurs > 1;
+                    isArray = parent.MaxOccurs > 1;
                 }
             }
 
@@ -740,7 +740,7 @@ namespace QbSync.XsdGenerator
                 else if (i == 1)
                 {
                     CodeTypeOfExpression arg2 = attribute.Arguments[i].Value as CodeTypeOfExpression;
-                    enhancedProperty.Type = arg2.Type.BaseType as string;
+                    enhancedProperty.Type = arg2.Type.BaseType + string.Concat(Enumerable.Repeat("[]", arg2.Type.ArrayRank));
                 }
                     /* // NOT WORKING with XmlSerializer.
                      * // If we remove the DataType attribute we get a "cannot create temporary class"

--- a/test/QbXml.Tests/Messages/Requests/TransactionQueryRqTypeTests.cs
+++ b/test/QbXml.Tests/Messages/Requests/TransactionQueryRqTypeTests.cs
@@ -1,0 +1,26 @@
+﻿using NUnit.Framework;
+using QbSync.QbXml.Objects;
+
+namespace QbSync.QbXml.Tests.QbXml
+{
+    [TestFixture]
+    public class TransactionQueryRqTypeTests
+    {
+        [Test]
+        public void TransactionTypeFilterArray()
+        {
+            var filter = new TxnTypeFilter[]
+            {
+                TxnTypeFilter.Invoice
+            };
+
+            var request = new TransactionQueryRqType
+            {
+                TransactionTypeFilter = filter
+            };
+
+            Assert.AreEqual(filter, request.TransactionTypeFilter);
+        }
+    }
+}
+


### PR DESCRIPTION
An old bugfix we discussed once upon a time and I never did a PR for. The XSD definition for `TransactionFilter` specifies ref element `TransactionTypeFilter`:

```xml
<xsd:group name="TransactionFilter">
	<xsd:sequence>
		<xsd:element ref="MaxReturned" minOccurs="0"/>
		<xsd:choice minOccurs="0">
			<xsd:element ref="RefNumber" maxOccurs="unbounded"/>
			<xsd:element ref="RefNumberCaseSensitive" maxOccurs="unbounded"/>
			<xsd:element ref="RefNumberFilter"/>
			<xsd:element ref="RefNumberRangeFilter"/>
		</xsd:choice>
		<xsd:element ref="TransactionModifiedDateRangeFilter" minOccurs="0"/>
		<xsd:element ref="TransactionDateRangeFilter" minOccurs="0"/>
		<xsd:element ref="TransactionEntityFilter" minOccurs="0"/>
		<xsd:element ref="TransactionAccountFilter" minOccurs="0"/>
		<xsd:element ref="TransactionItemFilter" minOccurs="0"/>
		<xsd:element ref="TransactionClassFilter" minOccurs="0"/>
		<xsd:element ref="TransactionTypeFilter" minOccurs="0"/>
		<xsd:element ref="TransactionDetailLevelFilter" minOccurs="0"/>
		<xsd:element ref="TransactionPostingStatusFilter" minOccurs="0"/>
		<xsd:element ref="TransactionPaidStatusFilter" minOccurs="0"/>
		<xsd:element ref="CurrencyFilter" minOccurs="0"/>
	</xsd:sequence>
</xsd:group>
```

```xml
<xsd:element name="TransactionTypeFilter">
	<xsd:complexType>
		<xsd:sequence>
			<xsd:element ref="TxnTypeFilter" maxOccurs="unbounded"/>
		</xsd:sequence>
	</xsd:complexType>
</xsd:element>
```

Before this fix, when trying to use the `TransactionTypeFilter` property, QuickBooks would return an error, ie:
```cs
var req = new TransactionQueryRqType
{
    TransactionTypeFilter = TxnTypeFilter.Check
};
```
QuickBooks is expecting an array of `TxnTypeFilter` (note the 'maxOccurs="unbounded"'). This fix updates the generator so the `TransactionTypeFilter` property has type `TxnTypeFilter[]`. This changes the usage to:

```cs
var req = new TransactionQueryRqType
{
    TransactionTypeFilter = new[] { TxnTypeFilter.Check }
};
```

This is technically a breaking change, however if anyone was using that property before their application was probably already broken. 