### PR TITLE
Allow deserialization events to be passed

### DIFF
--- a/src/QbXml/QbXmlResponse.cs
+++ b/src/QbXml/QbXmlResponse.cs
@@ -25,6 +25,7 @@ namespace QbSync.QbXml
         /// Parses a string and returns a QBXML object.
         /// </summary>
         /// <param name="response">XML.</param>
+        /// <param name="events">XmlDeserializationEvents that could be triggered while deserializing</param>
         /// <returns>QBXML object.</returns>
         public QBXML ParseResponseRaw(string response, XmlDeserializationEvents events = new XmlDeserializationEvents())
         {
@@ -38,6 +39,7 @@ namespace QbSync.QbXml
         /// </summary>
         /// <typeparam name="T">Object to get.</typeparam>
         /// <param name="response">XML.</param>
+        /// <param name="events">XmlDeserializationEvents that could be triggered while deserializing</param>
         /// <returns>Object instance.</returns>
         public T GetSingleItemFromResponse<T>(string response, XmlDeserializationEvents events = new XmlDeserializationEvents())
             where T : class
@@ -50,6 +52,7 @@ namespace QbSync.QbXml
         /// </summary>
         /// <typeparam name="T">Objects to get.</typeparam>
         /// <param name="response">XML.</param>
+        /// <param name="events">XmlDeserializationEvents that could be triggered while deserializing</param>
         /// <returns>Object instances.</returns>
         public IEnumerable<T> GetItemsFromResponse<T>(string response, XmlDeserializationEvents events = new XmlDeserializationEvents())
             where T : class
@@ -62,6 +65,7 @@ namespace QbSync.QbXml
         /// </summary>
         /// <param name="response">XML.</param>
         /// <param name="type">Object to get.</param>
+        /// <param name="events">XmlDeserializationEvents that could be triggered while deserializing</param>
         /// <returns>Object instance.</returns>
         public object GetSingleItemFromResponse(string response, System.Type type, XmlDeserializationEvents events = new XmlDeserializationEvents())
         {
@@ -73,6 +77,7 @@ namespace QbSync.QbXml
         /// </summary>
         /// <param name="response">XML.</param>
         /// <param name="type">Objects to get</param>
+        /// <param name="events">XmlDeserializationEvents that could be triggered while deserializing</param>
         /// <returns>Object instances.</returns>
         public IEnumerable<object> GetItemsFromResponse(string response, System.Type type, XmlDeserializationEvents events = new XmlDeserializationEvents())
         {

--- a/src/QbXml/QbXmlResponse.cs
+++ b/src/QbXml/QbXmlResponse.cs
@@ -27,11 +27,14 @@ namespace QbSync.QbXml
         /// <param name="response">XML.</param>
         /// <param name="events">XmlDeserializationEvents that could be triggered while deserializing</param>
         /// <returns>QBXML object.</returns>
-        public QBXML ParseResponseRaw(string response, XmlDeserializationEvents events = new XmlDeserializationEvents())
+        public QBXML ParseResponseRaw(string response, XmlDeserializationEvents? events = null)
         {
-            var reader = XmlReader.Create(new StringReader(response));
-            var ret = QbXmlSerializer.Instance.XmlSerializer.Deserialize(reader, events) as QBXML;
-            return ret;
+            var reader = new StringReader(response);
+            if (events.HasValue)
+            {
+                return QbXmlSerializer.Instance.XmlSerializer.Deserialize(XmlReader.Create(reader), events.Value) as QBXML;
+            }
+            return QbXmlSerializer.Instance.XmlSerializer.Deserialize(reader) as QBXML;
         }
 
         /// <summary>
@@ -41,7 +44,7 @@ namespace QbSync.QbXml
         /// <param name="response">XML.</param>
         /// <param name="events">XmlDeserializationEvents that could be triggered while deserializing</param>
         /// <returns>Object instance.</returns>
-        public T GetSingleItemFromResponse<T>(string response, XmlDeserializationEvents events = new XmlDeserializationEvents())
+        public T GetSingleItemFromResponse<T>(string response, XmlDeserializationEvents? events = null)
             where T : class
         {
             return GetSingleItemFromResponse(response, typeof(T), events) as T;
@@ -54,7 +57,7 @@ namespace QbSync.QbXml
         /// <param name="response">XML.</param>
         /// <param name="events">XmlDeserializationEvents that could be triggered while deserializing</param>
         /// <returns>Object instances.</returns>
-        public IEnumerable<T> GetItemsFromResponse<T>(string response, XmlDeserializationEvents events = new XmlDeserializationEvents())
+        public IEnumerable<T> GetItemsFromResponse<T>(string response, XmlDeserializationEvents? events = null)
             where T : class
         {
             return GetItemsFromResponse(response, typeof(T), events).Cast<T>();
@@ -67,7 +70,7 @@ namespace QbSync.QbXml
         /// <param name="type">Object to get.</param>
         /// <param name="events">XmlDeserializationEvents that could be triggered while deserializing</param>
         /// <returns>Object instance.</returns>
-        public object GetSingleItemFromResponse(string response, System.Type type, XmlDeserializationEvents events = new XmlDeserializationEvents())
+        public object GetSingleItemFromResponse(string response, System.Type type, XmlDeserializationEvents? events = null)
         {
             return GetItemsFromResponse(response, type, events).FirstOrDefault();
         }
@@ -79,7 +82,7 @@ namespace QbSync.QbXml
         /// <param name="type">Objects to get</param>
         /// <param name="events">XmlDeserializationEvents that could be triggered while deserializing</param>
         /// <returns>Object instances.</returns>
-        public IEnumerable<object> GetItemsFromResponse(string response, System.Type type, XmlDeserializationEvents events = new XmlDeserializationEvents())
+        public IEnumerable<object> GetItemsFromResponse(string response, System.Type type, XmlDeserializationEvents? events = null)
         {
             var qbXml = ParseResponseRaw(response, events);
             return SearchFor(qbXml, type);

--- a/src/QbXml/QbXmlResponse.cs
+++ b/src/QbXml/QbXmlResponse.cs
@@ -3,6 +3,9 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Reflection;
+using System.Xml;
+using System.Xml.Serialization;
 
 namespace QbSync.QbXml
 {
@@ -23,10 +26,10 @@ namespace QbSync.QbXml
         /// </summary>
         /// <param name="response">XML.</param>
         /// <returns>QBXML object.</returns>
-        public QBXML ParseResponseRaw(string response)
+        public QBXML ParseResponseRaw(string response, XmlDeserializationEvents events = new XmlDeserializationEvents())
         {
-            var reader = new StringReader(response);
-            var ret = QbXmlSerializer.Instance.XmlSerializer.Deserialize(reader) as QBXML;
+            var reader = XmlReader.Create(new StringReader(response));
+            var ret = QbXmlSerializer.Instance.XmlSerializer.Deserialize(reader, events) as QBXML;
             return ret;
         }
 
@@ -36,10 +39,10 @@ namespace QbSync.QbXml
         /// <typeparam name="T">Object to get.</typeparam>
         /// <param name="response">XML.</param>
         /// <returns>Object instance.</returns>
-        public T GetSingleItemFromResponse<T>(string response)
+        public T GetSingleItemFromResponse<T>(string response, XmlDeserializationEvents events = new XmlDeserializationEvents())
             where T : class
         {
-            return GetSingleItemFromResponse(response, typeof(T)) as T;
+            return GetSingleItemFromResponse(response, typeof(T), events) as T;
         }
 
         /// <summary>
@@ -48,10 +51,10 @@ namespace QbSync.QbXml
         /// <typeparam name="T">Objects to get.</typeparam>
         /// <param name="response">XML.</param>
         /// <returns>Object instances.</returns>
-        public IEnumerable<T> GetItemsFromResponse<T>(string response)
+        public IEnumerable<T> GetItemsFromResponse<T>(string response, XmlDeserializationEvents events = new XmlDeserializationEvents())
             where T : class
         {
-            return GetItemsFromResponse(response, typeof(T)).Cast<T>();
+            return GetItemsFromResponse(response, typeof(T), events).Cast<T>();
         }
 
         /// <summary>
@@ -60,9 +63,9 @@ namespace QbSync.QbXml
         /// <param name="response">XML.</param>
         /// <param name="type">Object to get.</param>
         /// <returns>Object instance.</returns>
-        public object GetSingleItemFromResponse(string response, System.Type type)
+        public object GetSingleItemFromResponse(string response, System.Type type, XmlDeserializationEvents events = new XmlDeserializationEvents())
         {
-            return GetItemsFromResponse(response, type).FirstOrDefault();
+            return GetItemsFromResponse(response, type, events).FirstOrDefault();
         }
 
         /// <summary>
@@ -71,9 +74,9 @@ namespace QbSync.QbXml
         /// <param name="response">XML.</param>
         /// <param name="type">Objects to get</param>
         /// <returns>Object instances.</returns>
-        public IEnumerable<object> GetItemsFromResponse(string response, System.Type type)
+        public IEnumerable<object> GetItemsFromResponse(string response, System.Type type, XmlDeserializationEvents events = new XmlDeserializationEvents())
         {
-            var qbXml = ParseResponseRaw(response);
+            var qbXml = ParseResponseRaw(response, events);
             return SearchFor(qbXml, type);
         }
 

--- a/src/WebConnector/Core/IStepQueryResponse.cs
+++ b/src/WebConnector/Core/IStepQueryResponse.cs
@@ -1,5 +1,6 @@
 ﻿using QbSync.QbXml;
 using System.Threading.Tasks;
+using System.Xml.Serialization;
 
 namespace QbSync.WebConnector.Core
 {
@@ -21,8 +22,9 @@ namespace QbSync.WebConnector.Core
         /// <param name="response">QbXml.</param>
         /// <param name="hresult">HResult.</param>
         /// <param name="message">Message.</param>
+        /// <param name="events">XmlDeserializationEvents that could be triggered while deserializing</param>
         /// <returns>Message to be returned to the Web Connector.</returns>
-        Task<int> ReceiveXMLAsync(IAuthenticatedTicket authenticatedTicket, string response, string hresult, string message);
+        Task<int> ReceiveXMLAsync(IAuthenticatedTicket authenticatedTicket, string response, string hresult, string message, XmlDeserializationEvents? events = null);
 
         /// <summary>
         /// Called when the Web Connector detected an error.

--- a/src/WebConnector/Impl/GroupStepQueryResponseBase.cs
+++ b/src/WebConnector/Impl/GroupStepQueryResponseBase.cs
@@ -1,10 +1,11 @@
-﻿using QbSync.QbXml;
-using QbSync.QbXml.Objects;
-using QbSync.WebConnector.Core;
-using System.Collections;
+﻿using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using System.Xml.Serialization;
+using QbSync.QbXml;
+using QbSync.QbXml.Objects;
+using QbSync.WebConnector.Core;
 
 namespace QbSync.WebConnector.Impl
 {
@@ -33,14 +34,15 @@ namespace QbSync.WebConnector.Impl
         /// <param name="response">QbXml.</param>
         /// <param name="hresult">HResult.</param>
         /// <param name="message">Message.</param>
+        /// <param name="events">XmlDeserializationEvents that could be triggered while deserializing</param>
         /// <returns>Message to be returned to the Web Connector.</returns>
-        public virtual async Task<int> ReceiveXMLAsync(IAuthenticatedTicket authenticatedTicket, string response, string hresult, string message)
+        public virtual async Task<int> ReceiveXMLAsync(IAuthenticatedTicket authenticatedTicket, string response, string hresult, string message, XmlDeserializationEvents? events = null)
         {
             var responseObject = new QbXmlResponse();
 
             if (!string.IsNullOrEmpty(response))
             {
-                var objects = responseObject.GetItemsFromResponse(response, typeof(IQbResponse));
+                var objects = responseObject.GetItemsFromResponse(response, typeof(IQbResponse), events);
                 var msgResponseObject = ((IEnumerable)objects).Cast<IQbResponse>();
                 await ExecuteResponseAsync(authenticatedTicket, msgResponseObject);
 

--- a/src/WebConnector/Impl/StepQueryResponseBase.cs
+++ b/src/WebConnector/Impl/StepQueryResponseBase.cs
@@ -2,6 +2,7 @@
 using QbSync.QbXml.Objects;
 using QbSync.WebConnector.Core;
 using System.Threading.Tasks;
+using System.Xml.Serialization;
 
 namespace QbSync.WebConnector.Impl
 {
@@ -32,14 +33,15 @@ namespace QbSync.WebConnector.Impl
         /// <param name="response">QbXml.</param>
         /// <param name="hresult">HResult.</param>
         /// <param name="message">Message.</param>
+        /// <param name="events">XmlDeserializationEvents that could be triggered while deserializing</param>
         /// <returns>Message to be returned to the Web Connector.</returns>
-        public virtual async Task<int> ReceiveXMLAsync(IAuthenticatedTicket authenticatedTicket, string response, string hresult, string message)
+        public virtual async Task<int> ReceiveXMLAsync(IAuthenticatedTicket authenticatedTicket, string response, string hresult, string message, XmlDeserializationEvents? events = null)
         {
             var responseObject = new QbXmlResponse();
 
             if (!string.IsNullOrEmpty(response))
             {
-                var msgResponseObject = responseObject.GetSingleItemFromResponse(response, typeof(QbResponse)) as QbResponse;
+                var msgResponseObject = responseObject.GetSingleItemFromResponse(response, typeof(QbResponse), events) as QbResponse;
                 await ExecuteResponseAsync(authenticatedTicket, msgResponseObject);
 
                 return 0;

--- a/test/QbXml.Tests/Messages/Responses/EmployeeQueryResponseTests.cs
+++ b/test/QbXml.Tests/Messages/Responses/EmployeeQueryResponseTests.cs
@@ -1,0 +1,133 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Xml.Serialization;
+using NUnit.Framework;
+using QbSync.QbXml;
+using QbSync.QbXml.Objects;
+using QbSync.QbXml.Tests.Helpers;
+
+namespace QbSync.QbXml.Tests.QbXml
+{
+    [TestFixture]
+    class EmployeeQueryResponseTests
+    {
+        [Test]
+        public void EmployeeResponseWithUnknownTagsTest()
+        {
+			var employeeRet = @"
+<EmployeeRet>
+    <ListID>1111111-111111111</ListID>
+    <EditSequence>1234567890</EditSequence>
+    <Name>Daric Teske</Name>
+    <IsActive>true</IsActive>
+    <FirstName>Daric</FirstName>
+    <LastName>Teske</LastName>
+    <Phone>5555555555</Phone>
+    <Email>tesked@outlook.com</Email>
+    <EmployeePayrollInfo>
+        <IsCoveredByQualifiedPensionPlan>false</IsCoveredByQualifiedPensionPlan>
+        <PayPeriod>Weekly</PayPeriod>
+        <PayScheduleRef>
+            <ListID>80000001-1286898172</ListID>
+            <FullName>Weekly</FullName>
+        </PayScheduleRef>
+        <Earnings>
+            <PayrollItemWageRef>
+                <ListID>80000000-0000000001</ListID>
+                <FullName>Field</FullName>
+            </PayrollItemWageRef>
+            <Rate>15.00</Rate>
+        </Earnings>
+        <Earnings>
+            <PayrollItemWageRef>
+                <ListID>80000000-0000000002</ListID>
+                <FullName>Field Overtime</FullName>
+            </PayrollItemWageRef>
+            <Rate>25.00</Rate>
+        </Earnings>
+        <Earnings>
+            <PayrollItemWageRef>
+                <ListID>80000000-0000000003</ListID>
+                <FullName>Field Double Time</FullName>
+            </PayrollItemWageRef>
+            <Rate>50.00</Rate>
+        </Earnings>
+        <Earnings>
+            <PayrollItemWageRef>
+                <ListID>80000000-0000000004</ListID>
+                <FullName>Field Holiday</FullName>
+            </PayrollItemWageRef>
+            <Rate>30.00</Rate>
+        </Earnings>
+        <UseTimeDataToCreatePaychecks>UseTimeData</UseTimeDataToCreatePaychecks>
+        <SickHours>
+            <HoursAvailable>PT0H15M0S</HoursAvailable>
+            <AccrualPeriod>EveryPaycheck</AccrualPeriod>
+            <HoursAccrued>PT0H55M0S</HoursAccrued>
+            <MaximumHours>PT48H0M0S</MaximumHours>
+            <IsResettingHoursEachNewYear>false</IsResettingHoursEachNewYear>
+            <HoursUsed>PT0H0M0S</HoursUsed>
+            <YearBeginsDate>2020-01-01</YearBeginsDate>
+            <AccrualStartDate>2000-01-01</AccrualStartDate>
+        </SickHours>
+        <VacationHours>
+            <HoursAvailable>PT0H0M0S</HoursAvailable>
+            <AccrualPeriod>EveryPaycheck</AccrualPeriod>
+            <HoursAccrued>PT0H0M0S</HoursAccrued>
+            <MaximumHours>PT0H0M0S</MaximumHours>
+            <IsResettingHoursEachNewYear>false</IsResettingHoursEachNewYear>
+            <HoursUsed>PT0H0M0S</HoursUsed>
+            <YearBeginsDate>2020-01-01</YearBeginsDate>
+            <AccrualStartDate>2000-01-01</AccrualStartDate>
+        </VacationHours>
+        <EmployeeTaxInfo>
+            <StateLived>NE</StateLived>
+            <StateWorked>NE</StateWorked>
+            <IsStandardTaxationRequired>true</IsStandardTaxationRequired>
+            <EmployeeTax>
+                <IsSubjectToTax>true</IsSubjectToTax>
+                <PayrollItemTaxRef>
+                    <ListID>D0000-863012697</ListID>
+                    <FullName>Federal Withholding</FullName>
+                </PayrollItemTaxRef>
+                <TaxInfo>
+                    <TaxInfoCategory>ALLOWANCES</TaxInfoCategory>
+                    <TaxInfoValue>1</TaxInfoValue>
+                </TaxInfo>
+                <TaxInfo>
+                    <TaxInfoCategory>EXTRA_WITHHOLDING</TaxInfoCategory>
+                    <TaxInfoValue>0.00</TaxInfoValue>
+                </TaxInfo>
+                <TaxInfo>
+                    <TaxInfoCategory>FILING_STATUS</TaxInfoCategory>
+                    <TaxInfoValue>256</TaxInfoValue>
+                </TaxInfo>
+            </EmployeeTax>
+        </EmployeeTaxInfo>
+        <EmployeeDirectDepositAccount>
+            <BankName>Fake Bank</BankName>
+            <RoutingNumber>111111111</RoutingNumber>
+            <AccountNumber>111111111111</AccountNumber>
+            <BankAccountType>Checking</BankAccountType>
+        </EmployeeDirectDepositAccount>
+    </EmployeePayrollInfo>
+</EmployeeRet>";
+            var response = new QbXmlResponse();
+            var unknownElements = 0;
+            XmlDeserializationEvents events = new XmlDeserializationEvents();
+            events.OnUnknownElement += (object sender, XmlElementEventArgs e) =>
+            {
+                unknownElements++;
+            };
+            var rs = response.GetSingleItemFromResponse<EmployeeQueryRsType>(QuickBooksTestHelper.CreateQbXmlWithEnvelope(employeeRet, "EmployeeQueryRs"), events);
+
+            var employees = rs.EmployeeRet;
+            var employee = employees[0];
+
+            Assert.AreEqual(1, employees.Length);
+            Assert.AreEqual("1111111-111111111", employee.ListID);
+            Assert.GreaterOrEqual(unknownElements, 1);
+        }
+    }
+}

--- a/test/WebConnector.Tests/Impl/QbManagerTests.cs
+++ b/test/WebConnector.Tests/Impl/QbManagerTests.cs
@@ -305,7 +305,7 @@ namespace QbSync.WebConnector.Tests.Impl
         {
             var expectedResult = 0;
             stepQueryResponseMock
-                .Setup(m => m.ReceiveXMLAsync(AuthenticatedTicket, null, null, null))
+                .Setup(m => m.ReceiveXMLAsync(AuthenticatedTicket, null, null, null, null))
                 .ReturnsAsync(expectedResult);
             stepQueryResponseMock
                 .Setup(m => m.GotoNextStepAsync())
@@ -328,7 +328,7 @@ namespace QbSync.WebConnector.Tests.Impl
             var expectedResult = 0;
             var gotoStep = "step2";
             stepQueryResponseMock
-                .Setup(m => m.ReceiveXMLAsync(AuthenticatedTicket, null, null, null))
+                .Setup(m => m.ReceiveXMLAsync(AuthenticatedTicket, null, null, null, null))
                 .ReturnsAsync(expectedResult);
             stepQueryResponseMock
                 .Setup(m => m.GotoStepAsync())
@@ -350,7 +350,7 @@ namespace QbSync.WebConnector.Tests.Impl
         {
             var expectedResult = 0;
             stepQueryResponseMock
-                .Setup(m => m.ReceiveXMLAsync(AuthenticatedTicket, null, null, null))
+                .Setup(m => m.ReceiveXMLAsync(AuthenticatedTicket, null, null, null, null))
                 .ReturnsAsync(expectedResult);
             stepQueryResponseMock
                 .Setup(m => m.GotoNextStepAsync())
@@ -373,7 +373,7 @@ namespace QbSync.WebConnector.Tests.Impl
         {
             var expectedResult = -1;
             stepQueryResponseMock
-                .Setup(m => m.ReceiveXMLAsync(AuthenticatedTicket, null, null, null))
+                .Setup(m => m.ReceiveXMLAsync(AuthenticatedTicket, null, null, null, null))
                 .ReturnsAsync(expectedResult);
             stepQueryResponseMock
                 .SetupGet(m => m.Name)
@@ -486,7 +486,7 @@ namespace QbSync.WebConnector.Tests.Impl
         {
             var ex = new Exception();
             stepQueryResponseMock
-                .Setup(m => m.ReceiveXMLAsync(AuthenticatedTicket, null, null, null))
+                .Setup(m => m.ReceiveXMLAsync(AuthenticatedTicket, null, null, null, null))
                 .Throws(ex);
 
             var guid = Guid.NewGuid().ToString();
@@ -501,7 +501,7 @@ namespace QbSync.WebConnector.Tests.Impl
             var expectedResult = -1;
             var IStepQueryResponseMock1 = new Mock<IStepQueryResponse>();
             IStepQueryResponseMock1
-                .Setup(m => m.ReceiveXMLAsync(AuthenticatedTicket, null, null, null))
+                .Setup(m => m.ReceiveXMLAsync(AuthenticatedTicket, null, null, null, null))
                 .Throws(ex);
 
             var result = await syncManagerMock.Object.ReceiveRequestXMLAsync(guid, null, null, null);


### PR DESCRIPTION
In relation to #47, this was all that I was able to come up with to help resolve my issues while not impacting the overall schema validation that's already in place.

By allowing the deserialization events to be passed, consumers of the package can easily implement their own error handling for issues that occur during deserialization, rather than quietly assigning null.

https://docs.microsoft.com/en-us/dotnet/api/system.xml.serialization.xmldeserializationevents?view=netframework-4.7.2