### PR TITLE
.NET 7.0 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,11 @@ language: csharp
 mono: latest
 dist: xenial
 sudo: required
-dotnet: 5.0.202
+dotnet: 7.0.100
 solution: QuickbooksSync.sln
 install:
   - dotnet restore
-  - nuget install NUnit.ConsoleRunner -Version 3.7.0 -OutputDirectory testrunner
+  - nuget install NUnit.ConsoleRunner -Version 3.16.0 -OutputDirectory testrunner
 script:
   - dotnet build --configuration Release ./src/QbXml/QbXml.csproj
   - dotnet build --configuration Release --no-restore ./test/QbXml.Tests/QbXml.Tests.csproj

--- a/src/WebConnector.AspNetCore/Extensions/ApplicationBuilderExtensions.cs
+++ b/src/WebConnector.AspNetCore/Extensions/ApplicationBuilderExtensions.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Extensions.DependencyInjection
                     SoapSerializer.XmlSerializer,
                     false,
                     null,
-                    new BasicHttpBinding()
+                    new WsdlFileOptions()
                 );
 
             return app;

--- a/src/WebConnector.AspNetCore/WebConnector.AspNetCore.csproj
+++ b/src/WebConnector.AspNetCore/WebConnector.AspNetCore.csproj
@@ -8,7 +8,7 @@
     <Author>Jean-Sébastien Goupil</Author>
     <Authors>Jean-Sébastien Goupil</Authors>
     <Copyright>Copyright © Jean-Sébastien Goupil 2015-2021</Copyright>
-    <Version>3.0.2</Version>
+    <Version>3.1.0</Version>
     <AssemblyName>QbSync.WebConnector.AspNetCore</AssemblyName>
     <RootNamespace>QbSync.WebConnector.AspNetCore</RootNamespace>
     <PackageId>QbSync.WebConnector.AspNetCore</PackageId>
@@ -23,7 +23,7 @@
     <None Include="..\..\LICENSE.md" Link="LICENSE.md" Pack="true" PackagePath="$(PackageLicenseFile)" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="SoapCore" Version="1.0.0" />
+    <PackageReference Include="SoapCore" Version="[1.1.0.36, 1.1.1.0)" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\WebConnector\WebConnector.csproj" />

--- a/src/WebConnector/WebConnector.csproj
+++ b/src/WebConnector/WebConnector.csproj
@@ -8,7 +8,7 @@
     <Author>Jean-Sébastien Goupil</Author>
     <Authors>Jean-Sébastien Goupil</Authors>
     <Copyright>Copyright © Jean-Sébastien Goupil 2015-2021</Copyright>
-    <Version>3.0.2</Version>
+    <Version>3.1.0</Version>
     <AssemblyName>QbSync.WebConnector</AssemblyName>
     <RootNamespace>QbSync.WebConnector</RootNamespace>
     <PackageId>QbSync.WebConnector</PackageId>
@@ -23,7 +23,7 @@
     <None Include="..\..\LICENSE.md" Link="LICENSE.md" Pack="true" PackagePath="$(PackageLicenseFile)" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.ServiceModel.Primitives" Version="4.5.0" />
+    <PackageReference Include="System.ServiceModel.Primitives" Version="4.5.3" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\QbXml\QbXml.csproj" />

--- a/test/QbXml.Tests/QbXml.Tests.csproj
+++ b/test/QbXml.Tests/QbXml.Tests.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <Title>QbXml.Tests</Title>
     <Author>Jean-Sébastien Goupil</Author>
     <Copyright>Copyright © Jean-Sébastien Goupil 2015-2020</Copyright>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
-    <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\QbXml\QbXml.csproj" />

--- a/test/WebApplication.Sample/WebApplication.Sample.csproj
+++ b/test/WebApplication.Sample/WebApplication.Sample.csproj
@@ -1,16 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.0">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="5.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="7.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\QbXml\QbXml.csproj" />

--- a/test/WebConnector.Tests/WebConnector.Tests.csproj
+++ b/test/WebConnector.Tests/WebConnector.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <Title>QbWebConnector.Tests</Title>
     <Author>Jean-Sébastien Goupil</Author>
     <Copyright>Copyright © Jean-Sébastien Goupil 2015-2020</Copyright>
@@ -11,13 +11,13 @@
     <None Include="Impl\QbManagerTests.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
-    <PackageReference Include="Moq" Version="4.15.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
+    <PackageReference Include="Moq" Version="4.18.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\WebConnector.AspNetCore\WebConnector.AspNetCore.csproj" />


### PR DESCRIPTION
Upgraded SoapCore from `1.0.0` version to  `[1.1.0.36, 1.1.1.0)`.

Upgraded sample app to run on .NET 7.0.

Upgraded Travis .NET SDK to `7.0.100`.

Upgraded vulnerable packages to the recommended versions (merge requests #63 and #61 not needed anymore).

Upgraded tests related packages.

Bumped `WebConnector` and `WebConnector.AspNetCore` versions to `3.1.0`.

Tests are passing, sample app works. Some tests depend on current locale.